### PR TITLE
feat(docs): add markdown_file_to_doc for robust large-file Markdown publishing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,6 @@ kuzu-memories/
 .kuzu-memory/
 .kuzu_memory.db
 .trusty-search/
+
+# FastEmbed local model/vector cache
+.fastembed_cache/

--- a/.gitignore
+++ b/.gitignore
@@ -94,3 +94,4 @@ docs/research/
 kuzu-memories/
 .kuzu-memory/
 .kuzu_memory.db
+.trusty-search/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`format_document_tables`** — new MCP tool that post-processes ALL tables in a Google Doc
+  in a single call, fixing the two most common import artefacts:
+  1. **Visible cell borders**: applies 1pt solid dark-grey borders to every cell on all four
+     sides via `updateTableCellStyle` batchUpdate, guaranteeing borders even after Markdown→DOCX→
+     Drive import strips them.
+  2. **Content-aware column widths**: sets each column width proportional to the maximum cell
+     text length in that column (capped at 60 chars per column to prevent one long cell from
+     dominating), so text-heavy columns like "Work Type" become wide and numeric columns like
+     "%" stay narrow. Uses `updateTableColumnProperties` with `FIXED_WIDTH`.
+  3. **Header row styling**: first row gets light-grey background + bold text.
+  - Reads `documentStyle` for usable page width; falls back to 468pt (US Letter, 1-inch margins).
+  - Idempotent — safe to call multiple times on the same document.
+  - Unit-tested: `tests/unit/test_format_document_tables.py` covers the pure width algorithm
+    with 20 tests (sum invariant, longest-column ordering, min-clamp, cap enforcement, edge cases).
+
 - **`markdown_file_to_doc`** — new MCP tool that converts a Markdown file to a fully-formatted
   Google Doc, fixing three failure modes of `publish_markdown_to_doc`:
   1. **No inline-content truncation**: reads the file server-side via `markdown_file_path` so

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`markdown_file_to_doc`** — new MCP tool that converts a Markdown file to a fully-formatted
+  Google Doc, fixing three failure modes of `publish_markdown_to_doc`:
+  1. **No inline-content truncation**: reads the file server-side via `markdown_file_path` so
+     large documents (700+ lines / 70 KB+) are never cut off by context or output-token limits.
+  2. **Real table borders**: uses `updateTableCellStyle` directly after table insertion, guaranteeing
+     visible borders even after Drive import (which strips DOCX table borders).
+  3. **In-place update**: supply `document_id` to clear and rewrite an existing document body
+     while preserving the shareable link and document ID.
+  - Parameters: `markdown_file_path` (absolute path), `markdown_content` (inline fallback),
+    `title`, `document_id` (optional, for in-place update), `folder_id`, `account`.
+  - Supports headings H1–H6, paragraphs, fenced code blocks, GFM pipe tables, unordered and
+    ordered lists (depth-aware), horizontal rules, and inline bold/italic/code/links.
+
 - **Multi-account named profile support** — configure and switch between multiple Google accounts
 - `workspace setup --account NAME` — set up a named account profile via OAuth
 - `workspace accounts list` — list all configured profiles with default marker

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Supports headings H1–H6, paragraphs, fenced code blocks, GFM pipe tables, unordered and
     ordered lists (depth-aware), horizontal rules, and inline bold/italic/code/links.
 
+### Fixed
+
+- **`markdown_file_to_doc` — table cells scrambled**: table cell `insertText` requests are now
+  issued in **reverse document order** (last cell first) so each insertion does not shift the
+  indices of cells yet to be filled. Previously, forward-order insertion caused every subsequent
+  cell's index to be off by the cumulative characters already inserted, producing garbled or
+  transposed cell content (e.g. a 5-column table rendering as "MeMaFeRaDatCo52…").
+- **`markdown_file_to_doc` — hard line breaks collapsed**: lines ending in two trailing spaces
+  (Markdown hard break) now produce a literal `\n` run within the paragraph block instead of
+  being joined with a space. The 3-line status/date title block now renders as three separate
+  lines rather than one run-on paragraph.
+- **`markdown_file_to_doc` — emphasis over-matching**: `*italic*` and `**bold**` patterns now
+  require the content to start and end with a non-whitespace character (`\S`), preventing
+  stray `*` characters (e.g. `~49.7%*` footnote markers) and space-padded asterisks from
+  being incorrectly parsed as italic spans.
+- **`markdown_file_to_doc` — no font override on body text**: confirmed that `weightedFontFamily`
+  is only applied to inline code spans (Courier New) and never to plain body text or headings;
+  headings continue to use named heading styles so the document theme font is respected.
+
 - **Multi-account named profile support** — configure and switch between multiple Google accounts
 - `workspace setup --account NAME` — set up a named account profile via OAuth
 - `workspace accounts list` — list all configured profiles with default marker

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,16 +121,21 @@ src/google_workspace_mcp/
 - list_drive_contents, download_drive_folder (rclone)
 - upload_to_drive, sync_drive_folder (rclone)
 
-### Docs (17 tools)
+### Docs (18 tools)
 - create_document, append_to_document, get_document
 - upload_markdown_as_doc, publish_markdown_to_doc
 - list_document_comments, add_document_comment, reply_to_comment
 - **Document Tabs**: list_document_tabs, get_tab_content, create_document_tab, update_tab_properties, move_tab
 - **Mermaid Diagrams**: render_mermaid_to_doc (SVG/PNG conversion)
-- **Rich Formatting** (NEW):
+- **Rich Formatting**:
   - format_text_in_document, format_paragraph_in_document
   - apply_heading_style, set_document_margins
   - create_list_in_document, insert_table_in_document
+- **Table Post-Processing** (NEW):
+  - `format_document_tables(document_id, account?)` — walks all tables in a doc and applies
+    (1) 1pt solid borders on every cell, (2) bold+light-grey header row, (3) content-aware
+    column widths proportional to max cell length (cap=60, min=40pt). Reads usable width from
+    documentStyle; falls back to 468pt. Idempotent. Fixes Drive-import border/width artefacts.
 
 ### Sheets (13 tools) - NEW SERVICE
 - create_spreadsheet, get_spreadsheet_data, list_spreadsheet_sheets

--- a/src/gworkspace_mcp/server/services/docs/__init__.py
+++ b/src/gworkspace_mcp/server/services/docs/__init__.py
@@ -13,6 +13,7 @@ from gworkspace_mcp.server.services.docs import (
     headers_footers,
     markdown,
     markdown_file,
+    table_format,
     table_ops,
     templates,
 )
@@ -27,6 +28,7 @@ TOOLS: list[Tool] = (
     + markdown_file.TOOLS
     + formatting.TOOLS
     + table_ops.TOOLS
+    + table_format.TOOLS
     + templates.TOOLS
     + headers_footers.TOOLS
 )
@@ -42,6 +44,7 @@ def get_handlers(svc: BaseService) -> dict[str, Any]:
         markdown_file,
         formatting,
         table_ops,
+        table_format,
         templates,
         headers_footers,
     ]:

--- a/src/gworkspace_mcp/server/services/docs/__init__.py
+++ b/src/gworkspace_mcp/server/services/docs/__init__.py
@@ -12,6 +12,7 @@ from gworkspace_mcp.server.services.docs import (
     formatting,
     headers_footers,
     markdown,
+    markdown_file,
     table_ops,
     templates,
 )
@@ -23,6 +24,7 @@ TOOLS: list[Tool] = (
     comments.TOOLS
     + core.TOOLS
     + markdown.TOOLS
+    + markdown_file.TOOLS
     + formatting.TOOLS
     + table_ops.TOOLS
     + templates.TOOLS
@@ -33,6 +35,15 @@ TOOLS: list[Tool] = (
 def get_handlers(svc: BaseService) -> dict[str, Any]:
     """Return name->callable mapping for all Docs handlers."""
     handlers: dict[str, Any] = {}
-    for mod in [comments, core, markdown, formatting, table_ops, templates, headers_footers]:
+    for mod in [
+        comments,
+        core,
+        markdown,
+        markdown_file,
+        formatting,
+        table_ops,
+        templates,
+        headers_footers,
+    ]:
         handlers.update(mod.get_handlers(svc))
     return handlers

--- a/src/gworkspace_mcp/server/services/docs/markdown_file.py
+++ b/src/gworkspace_mcp/server/services/docs/markdown_file.py
@@ -11,8 +11,11 @@ Fixes three failure modes of publish_markdown_to_doc:
 
 from __future__ import annotations
 
+import json
 import logging
 import re
+import secrets
+import tempfile
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -344,12 +347,14 @@ def parse_markdown(content: str) -> list[dict[str, Any]]:
         if stripped.startswith("|") or (
             "|" in stripped and i + 1 < n and _is_separator_row(lines[i + 1])
         ):
-            # Collect consecutive table lines
+            # Collect consecutive table lines.
+            # A line is part of the table only when its stripped form starts
+            # with "|" OR matches a GFM separator row.  A blank line or any
+            # non-pipe-leading line terminates the table block, preventing
+            # greedy absorption of prose that merely contains a "|" character.
             table_lines: list[str] = []
             j = i
-            while j < n and (
-                lines[j].strip().startswith("|") or ("|" in lines[j] and not lines[j].strip() == "")
-            ):
+            while j < n and (lines[j].strip().startswith("|") or _is_separator_row(lines[j])):
                 table_lines.append(lines[j])
                 j += 1
             # Validate: need at least header + separator + 1 row
@@ -950,6 +955,28 @@ async def _batch_update(
 
 
 # ---------------------------------------------------------------------------
+# Path-traversal guard helper
+# ---------------------------------------------------------------------------
+
+
+def _is_path_under(path: Path, root: Path) -> bool:
+    """Return True if *path* is equal to or a descendant of *root*.
+
+    Why: Prevents path-traversal attacks where a caller supplies a path like
+    /etc/passwd to read arbitrary system files.
+    What: Uses Path.is_relative_to (Python 3.9+) to check containment after
+    both paths have been resolved (symlinks expanded, .. collapsed).
+    Test: Assert True for Path('/home/user/docs/file.md') under Path('/home/user');
+    assert False for Path('/etc/passwd') under Path('/home/user').
+    """
+    try:
+        path.relative_to(root)
+        return True
+    except ValueError:
+        return False
+
+
+# ---------------------------------------------------------------------------
 # Main handler
 # ---------------------------------------------------------------------------
 
@@ -966,8 +993,6 @@ async def _markdown_file_to_doc(svc: BaseService, arguments: dict[str, Any]) -> 
     6. Post-process: fill table cells, apply borders, heading styles.
     7. Return document id + webViewLink.
     """
-    import secrets
-
     markdown_file_path = arguments.get("markdown_file_path")
     markdown_content = arguments.get("markdown_content")
     title = arguments.get("title", "Untitled Document")
@@ -976,7 +1001,23 @@ async def _markdown_file_to_doc(svc: BaseService, arguments: dict[str, Any]) -> 
 
     # --- 1. Read markdown ---
     if markdown_file_path:
-        path = Path(markdown_file_path)
+        path = Path(markdown_file_path).resolve()
+        # Path-traversal guard: only allow reads under the current working directory,
+        # the user's home directory, or the system temp directory.
+        # This blocks /etc/passwd and other system files while keeping the tool
+        # practical for local MCP server usage (tmp files, home-dir docs, project files).
+        allowed_roots = (
+            Path.cwd().resolve(),
+            Path.home().resolve(),
+            Path(tempfile.gettempdir()).resolve(),
+        )
+        if not any(_is_path_under(path, root) for root in allowed_roots):
+            raise ValueError(
+                f"Path '{markdown_file_path}' is outside allowed directories "
+                f"({', '.join(str(r) for r in allowed_roots)}). "
+                "Only paths under the current working directory, your home directory, "
+                "or the system temp directory are permitted."
+            )
         if not path.is_file():
             raise FileNotFoundError(f"Markdown file not found: {markdown_file_path}")
         markdown_content = path.read_text(encoding="utf-8")
@@ -1016,8 +1057,6 @@ async def _markdown_file_to_doc(svc: BaseService, arguments: dict[str, Any]) -> 
     else:
         # Create new document
         if folder_id:
-            import json
-
             gdoc_metadata: dict[str, Any] = {
                 "name": title,
                 "mimeType": "application/vnd.google-apps.document",

--- a/src/gworkspace_mcp/server/services/docs/markdown_file.py
+++ b/src/gworkspace_mcp/server/services/docs/markdown_file.py
@@ -1,0 +1,1024 @@
+"""markdown_file_to_doc: robust Markdown-to-Google-Doc tool.
+
+Fixes three failure modes of publish_markdown_to_doc:
+1. Server-side file reading — no inline content required, so large docs (700+ lines)
+   are never truncated by context limits or output-token limits.
+2. Tables with borders — uses the Docs API updateTableCellStyle directly, guaranteeing
+   visible borders even after Drive import (which drops DOCX table borders).
+3. In-place update — when document_id is supplied, clears the existing body and
+   re-inserts; the shareable link is preserved.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from mcp.types import Tool
+
+from gworkspace_mcp.server.constants import DOCS_API_BASE, DRIVE_API_BASE
+
+if TYPE_CHECKING:
+    from gworkspace_mcp.server.base import BaseService
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Max requests per batchUpdate call.  Google Docs API allows up to 2000
+# requests per batchUpdate, but sending very large batches increases the
+# risk of hitting per-request payload size limits.  We use a conservative
+# chunk size that comfortably handles 700-line documents.
+# ---------------------------------------------------------------------------
+_BATCH_CHUNK_SIZE = 200
+
+# Border style applied to every table cell
+_TABLE_BORDER = {
+    "color": {"color": {"rgbColor": {"red": 0.4, "green": 0.4, "blue": 0.4}}},
+    "width": {"magnitude": 0.75, "unit": "PT"},
+    "dashStyle": "SOLID",
+}
+
+# Header row background (blue-grey)
+_HEADER_BG = {"red": 0.2, "green": 0.35, "blue": 0.6}
+
+# Heading level → Docs named style
+_HEADING_STYLE: dict[int, str] = {
+    1: "HEADING_1",
+    2: "HEADING_2",
+    3: "HEADING_3",
+    4: "HEADING_4",
+    5: "HEADING_5",
+    6: "HEADING_6",
+}
+
+# ---------------------------------------------------------------------------
+# Tool definition
+# ---------------------------------------------------------------------------
+
+TOOLS: list[Tool] = [
+    Tool(
+        name="markdown_file_to_doc",
+        description=(
+            "Convert a Markdown file to a fully-formatted Google Doc with real table borders, "
+            "inline hyperlinks, and correct heading styles.  Reads the file server-side so "
+            "large documents (700+ lines / 70 KB+) are never truncated.  "
+            "When document_id is supplied the existing document body is replaced in-place so "
+            "the shareable link is preserved; omit it to create a new document."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "markdown_file_path": {
+                    "type": "string",
+                    "description": (
+                        "Absolute path to the Markdown file on the server. "
+                        "The server reads the file directly — do NOT pass inline content here."
+                    ),
+                },
+                "markdown_content": {
+                    "type": "string",
+                    "description": (
+                        "Inline Markdown content (alternative to markdown_file_path for small "
+                        "documents).  If both are supplied, markdown_file_path takes precedence."
+                    ),
+                },
+                "title": {
+                    "type": "string",
+                    "description": "Document title.  Required when creating a new document.",
+                },
+                "document_id": {
+                    "type": "string",
+                    "description": (
+                        "Existing Google Doc ID to update in-place.  "
+                        "The document body is cleared and replaced — the ID and shareable link "
+                        "are preserved.  Omit to create a new document."
+                    ),
+                },
+                "folder_id": {
+                    "type": "string",
+                    "description": "Drive folder ID for the new document (ignored when document_id is supplied).",
+                },
+                "account": {
+                    "type": "string",
+                    "description": (
+                        "Google account profile to use.  Omit to use the default account.  "
+                        "Use 'workspace accounts list' to see available profiles."
+                    ),
+                },
+            },
+        },
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Markdown parser → list of "block" dicts
+# ---------------------------------------------------------------------------
+
+
+def _strip_inline_md(text: str) -> str:
+    """Remove bold/italic/code markers but keep link text."""
+    text = re.sub(r"\*\*(.+?)\*\*", r"\1", text)
+    text = re.sub(r"\*(.+?)\*", r"\1", text)
+    text = re.sub(r"__(.+?)__", r"\1", text)
+    text = re.sub(r"_(.+?)_", r"\1", text)
+    text = re.sub(r"`(.+?)`", r"\1", text)
+    # links: keep only label text for plain extraction
+    text = re.sub(r"\[(.+?)\]\(.+?\)", r"\1", text)
+    return text
+
+
+def _parse_inline_runs(text: str) -> list[dict[str, Any]]:
+    """Parse an inline text string into a list of run dicts.
+
+    Each run dict has:
+      - ``text``: the plain text content
+      - ``bold``: True if bold
+      - ``italic``: True if italic
+      - ``code``: True if inline code
+      - ``link``: URL string if this run is a hyperlink, else None
+
+    Nested emphasis is not supported; the first matching token wins.
+    """
+    runs: list[dict[str, Any]] = []
+
+    # Pattern order matters: links before bold/italic so [text](...) is parsed
+    # as a link rather than an italic fragment.
+    pattern = re.compile(
+        r"(?P<link>\[(?P<link_text>[^\]]+)\]\((?P<link_url>[^)]+)\))"
+        r"|(?P<bold>\*\*(?P<bold_text>.+?)\*\*)"
+        r"|(?P<bold2>__(?P<bold2_text>.+?)__)"
+        r"|(?P<italic>\*(?P<italic_text>.+?)\*)"
+        r"|(?P<italic2>_(?P<italic2_text>.+?)_)"
+        r"|(?P<code>`(?P<code_text>[^`]+)`)"
+    )
+
+    pos = 0
+    for m in pattern.finditer(text):
+        # Plain text before this match
+        if m.start() > pos:
+            runs.append(
+                {
+                    "text": text[pos : m.start()],
+                    "bold": False,
+                    "italic": False,
+                    "code": False,
+                    "link": None,
+                }
+            )
+        if m.group("link"):
+            runs.append(
+                {
+                    "text": m.group("link_text"),
+                    "bold": False,
+                    "italic": False,
+                    "code": False,
+                    "link": m.group("link_url"),
+                }
+            )
+        elif m.group("bold"):
+            runs.append(
+                {
+                    "text": m.group("bold_text"),
+                    "bold": True,
+                    "italic": False,
+                    "code": False,
+                    "link": None,
+                }
+            )
+        elif m.group("bold2"):
+            runs.append(
+                {
+                    "text": m.group("bold2_text"),
+                    "bold": True,
+                    "italic": False,
+                    "code": False,
+                    "link": None,
+                }
+            )
+        elif m.group("italic"):
+            runs.append(
+                {
+                    "text": m.group("italic_text"),
+                    "bold": False,
+                    "italic": True,
+                    "code": False,
+                    "link": None,
+                }
+            )
+        elif m.group("italic2"):
+            runs.append(
+                {
+                    "text": m.group("italic2_text"),
+                    "bold": False,
+                    "italic": True,
+                    "code": False,
+                    "link": None,
+                }
+            )
+        elif m.group("code"):
+            runs.append(
+                {
+                    "text": m.group("code_text"),
+                    "bold": False,
+                    "italic": False,
+                    "code": True,
+                    "link": None,
+                }
+            )
+        pos = m.end()
+
+    if pos < len(text):
+        runs.append(
+            {"text": text[pos:], "bold": False, "italic": False, "code": False, "link": None}
+        )
+
+    return runs or [{"text": text, "bold": False, "italic": False, "code": False, "link": None}]
+
+
+# Block types produced by the parser
+# heading:   {"type": "heading", "level": int, "runs": [...]}
+# paragraph: {"type": "paragraph", "runs": [...]}
+# code:      {"type": "code", "text": str}
+# table:     {"type": "table", "headers": [str], "rows": [[str]]}
+# bullet:    {"type": "bullet", "depth": int, "runs": [...]}
+# ordered:   {"type": "ordered", "index": int, "depth": int, "runs": [...]}
+# rule:      {"type": "rule"}
+# blank:     {"type": "blank"}
+
+
+def _parse_table(lines: list[str]) -> dict[str, Any]:
+    """Parse a GFM pipe-table block into a table block dict."""
+
+    def _parse_row(line: str) -> list[str]:
+        line = line.strip()
+        if line.startswith("|"):
+            line = line[1:]
+        if line.endswith("|"):
+            line = line[:-1]
+        return [cell.strip() for cell in line.split("|")]
+
+    headers = _parse_row(lines[0])
+    # lines[1] is the separator — skip it
+    rows = [_parse_row(line) for line in lines[2:] if line.strip()]
+    return {"type": "table", "headers": headers, "rows": rows}
+
+
+def _is_separator_row(line: str) -> bool:
+    return bool(re.match(r"^\|?[\s\-:|]+\|[\s\-:|]*(\|[\s\-:|]*)*\|?$", line.strip()))
+
+
+def parse_markdown(content: str) -> list[dict[str, Any]]:
+    """Parse Markdown content into a flat list of block dicts.
+
+    Handles:
+    - ATX headings (# through ######)
+    - Fenced code blocks (``` and ~~~)
+    - GFM pipe tables
+    - Unordered lists (-, *, +) with up to 2 levels of nesting
+    - Ordered lists (1. 2. ...) with up to 2 levels
+    - Horizontal rules (---, ***, ___)
+    - Paragraphs (everything else)
+
+    Inline formatting within paragraphs, headings, and list items:
+    - **bold**, __bold__
+    - *italic*, _italic_
+    - `code`
+    - [link text](url)
+    """
+    blocks: list[dict[str, Any]] = []
+    lines = content.splitlines()
+    i = 0
+    n = len(lines)
+
+    while i < n:
+        raw = lines[i]
+        stripped = raw.rstrip()
+
+        # ---- Fenced code block ----
+        fence_m = re.match(r"^(```|~~~)(.*)", stripped)
+        if fence_m:
+            fence_char = fence_m.group(1)
+            code_lines: list[str] = []
+            i += 1
+            while i < n and not lines[i].startswith(fence_char):
+                code_lines.append(lines[i])
+                i += 1
+            i += 1  # skip closing fence
+            blocks.append({"type": "code", "text": "\n".join(code_lines)})
+            continue
+
+        # ---- Horizontal rule ----
+        if (
+            re.match(r"^\s*[-*_]{3,}\s*$", stripped)
+            and stripped.replace("-", "").replace("*", "").replace("_", "").strip() == ""
+        ):
+            blocks.append({"type": "rule"})
+            i += 1
+            continue
+
+        # ---- ATX Heading ----
+        heading_m = re.match(r"^(#{1,6})\s+(.+?)(?:\s+#+)?$", stripped)
+        if heading_m:
+            level = len(heading_m.group(1))
+            text = heading_m.group(2)
+            blocks.append({"type": "heading", "level": level, "runs": _parse_inline_runs(text)})
+            i += 1
+            continue
+
+        # ---- GFM Table (peek ahead for separator row) ----
+        if stripped.startswith("|") or (
+            "|" in stripped and i + 1 < n and _is_separator_row(lines[i + 1])
+        ):
+            # Collect consecutive table lines
+            table_lines: list[str] = []
+            j = i
+            while j < n and (
+                lines[j].strip().startswith("|") or ("|" in lines[j] and not lines[j].strip() == "")
+            ):
+                table_lines.append(lines[j])
+                j += 1
+            # Validate: need at least header + separator + 1 row
+            if len(table_lines) >= 3 and _is_separator_row(table_lines[1]):
+                blocks.append(_parse_table(table_lines))
+                i = j
+                continue
+
+        # ---- Unordered list item ----
+        ul_m = re.match(r"^(\s*)[-*+]\s+(.+)$", stripped)
+        if ul_m:
+            depth = len(ul_m.group(1)) // 2  # 0 = top level
+            text = ul_m.group(2)
+            blocks.append({"type": "bullet", "depth": depth, "runs": _parse_inline_runs(text)})
+            i += 1
+            continue
+
+        # ---- Ordered list item ----
+        ol_m = re.match(r"^(\s*)(\d+)[.)]\s+(.+)$", stripped)
+        if ol_m:
+            depth = len(ol_m.group(1)) // 2
+            idx = int(ol_m.group(2))
+            text = ol_m.group(3)
+            blocks.append(
+                {"type": "ordered", "index": idx, "depth": depth, "runs": _parse_inline_runs(text)}
+            )
+            i += 1
+            continue
+
+        # ---- Blank line ----
+        if not stripped:
+            blocks.append({"type": "blank"})
+            i += 1
+            continue
+
+        # ---- Paragraph (catch-all) ----
+        # Collect continuation lines (non-blank, not a new block)
+        para_lines: list[str] = [stripped]
+        i += 1
+        while i < n:
+            next_raw = lines[i].rstrip()
+            if not next_raw:
+                break
+            if re.match(r"^#{1,6}\s", next_raw):
+                break
+            if re.match(r"^(```|~~~)", next_raw):
+                break
+            if re.match(r"^(\s*)[-*+]\s", next_raw):
+                break
+            if re.match(r"^(\s*)\d+[.)]\s", next_raw):
+                break
+            if re.match(r"^\s*[-*_]{3,}\s*$", next_raw):
+                break
+            para_lines.append(next_raw)
+            i += 1
+        paragraph_text = " ".join(para_lines)
+        blocks.append({"type": "paragraph", "runs": _parse_inline_runs(paragraph_text)})
+
+    return blocks
+
+
+# ---------------------------------------------------------------------------
+# Google Docs request builder
+# ---------------------------------------------------------------------------
+
+
+class _DocBuilder:
+    """Builds a list of Google Docs batchUpdate requests from parsed blocks.
+
+    Tracks the current insert index so requests are issued in document order.
+    All text is inserted via insertText requests first; then styling requests
+    (updateParagraphStyle, updateTextStyle, updateTableCellStyle) are appended.
+
+    Importantly: ALL text inserts must come before ALL style requests within
+    a chunk if we're building a fresh document from index=1.  For safety we
+    keep them interleaved per block — this is correct for sequential processing.
+    """
+
+    def __init__(self, start_index: int = 1) -> None:
+        self.index = start_index
+        self.requests: list[dict[str, Any]] = []
+        # Deferred table style requests (issued after all insertions for a table)
+        self._deferred: list[dict[str, Any]] = []
+
+    def _flush_deferred(self) -> None:
+        self.requests.extend(self._deferred)
+        self._deferred = []
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _insert_text(self, text: str) -> int:
+        """Emit insertText request and advance index.  Returns start index."""
+        start = self.index
+        self.requests.append(
+            {
+                "insertText": {
+                    "location": {"index": self.index},
+                    "text": text,
+                }
+            }
+        )
+        self.index += len(text)
+        return start
+
+    def _style_paragraph(self, start: int, end: int, named_style: str) -> None:
+        self.requests.append(
+            {
+                "updateParagraphStyle": {
+                    "range": {"startIndex": start, "endIndex": end},
+                    "paragraphStyle": {"namedStyleType": named_style},
+                    "fields": "namedStyleType",
+                }
+            }
+        )
+
+    def _style_text_run(
+        self,
+        start: int,
+        end: int,
+        bold: bool = False,
+        italic: bool = False,
+        code: bool = False,
+        link: str | None = None,
+    ) -> None:
+        if start >= end:
+            return
+        text_style: dict[str, Any] = {}
+        fields: list[str] = []
+        if bold:
+            text_style["bold"] = True
+            fields.append("bold")
+        if italic:
+            text_style["italic"] = True
+            fields.append("italic")
+        if code:
+            text_style["weightedFontFamily"] = {"fontFamily": "Courier New"}
+            fields.append("weightedFontFamily")
+        if link:
+            text_style["link"] = {"url": link}
+            fields.append("link")
+        if not fields:
+            return
+        self.requests.append(
+            {
+                "updateTextStyle": {
+                    "range": {"startIndex": start, "endIndex": end},
+                    "textStyle": text_style,
+                    "fields": ",".join(fields),
+                }
+            }
+        )
+
+    def _insert_runs(self, runs: list[dict[str, Any]]) -> tuple[int, int]:
+        """Insert runs into the document.  Returns (block_start, block_end)."""
+        block_start = self.index
+        for run in runs:
+            run_start = self.index
+            self._insert_text(run["text"])
+            run_end = self.index
+            if run["bold"] or run["italic"] or run["code"] or run["link"]:
+                self._style_text_run(
+                    run_start,
+                    run_end,
+                    bold=run["bold"],
+                    italic=run["italic"],
+                    code=run["code"],
+                    link=run["link"],
+                )
+        return block_start, self.index
+
+    # ------------------------------------------------------------------
+    # Block handlers
+    # ------------------------------------------------------------------
+
+    def add_heading(self, level: int, runs: list[dict[str, Any]]) -> None:
+        start = self.index
+        _, end = self._insert_runs(runs)
+        self._insert_text("\n")
+        self._style_paragraph(start, end + 1, _HEADING_STYLE.get(level, "HEADING_1"))
+
+    def add_paragraph(self, runs: list[dict[str, Any]]) -> None:
+        self._insert_runs(runs)
+        self._insert_text("\n")
+
+    def add_code_block(self, text: str) -> None:
+        # Insert code text with monospace font, paragraph as NORMAL_TEXT
+        start = self.index
+        code_text = text + "\n"
+        self._insert_text(code_text)
+        end = self.index
+        # Apply monospace to the whole block
+        self.requests.append(
+            {
+                "updateTextStyle": {
+                    "range": {"startIndex": start, "endIndex": end},
+                    "textStyle": {"weightedFontFamily": {"fontFamily": "Courier New"}},
+                    "fields": "weightedFontFamily",
+                }
+            }
+        )
+
+    def add_bullet(self, depth: int, runs: list[dict[str, Any]]) -> None:
+        start = self.index
+        _, end = self._insert_runs(runs)
+        self._insert_text("\n")
+        para_end = self.index
+        # Apply bullet list style
+        nesting_level = min(depth, 5)
+        self.requests.append(
+            {
+                "createParagraphBullets": {
+                    "range": {"startIndex": start, "endIndex": para_end},
+                    "bulletPreset": "BULLET_DISC_CIRCLE_SQUARE",
+                    "nestingLevel": nesting_level,
+                }
+            }
+        )
+        _ = end  # suppress unused warning
+
+    def add_ordered(self, runs: list[dict[str, Any]], depth: int = 0) -> None:
+        start = self.index
+        self._insert_runs(runs)
+        self._insert_text("\n")
+        para_end = self.index
+        nesting_level = min(depth, 5)
+        self.requests.append(
+            {
+                "createParagraphBullets": {
+                    "range": {"startIndex": start, "endIndex": para_end},
+                    "bulletPreset": "NUMBERED_DECIMAL_ALPHA_ROMAN",
+                    "nestingLevel": nesting_level,
+                }
+            }
+        )
+
+    def add_blank(self) -> None:
+        self._insert_text("\n")
+
+    def add_rule(self) -> None:
+        # Represent as a blank paragraph; Google Docs doesn't have a native HR
+        self._insert_text("─" * 60 + "\n")
+
+    def add_table(self, headers: list[str], rows: list[list[str]]) -> None:
+        """Insert a table with borders and a styled header row.
+
+        Strategy:
+        1. insertTable to create the grid
+        2. Re-fetch isn't available in the builder — instead we track the index
+           offset manually.  After insertTable the Docs API inserts:
+           - 1 char for the table element itself
+           - for each row: 1 char for the row element
+           - for each cell in a row: 1 char for the cell + content + 1 char for
+             the closing newline of the cell paragraph
+           We use the insertText/updateTableCellStyle approach instead:
+           After insertTable the doc acquires new structure that advances our
+           index by a known amount.
+
+        Because tracking insertTable cell indices without a re-fetch is fragile,
+        we use a simpler reliable approach: insert the table, then store the
+        table_start_index so we can do a deferred batchUpdate after we know all
+        indices via a GET.  However, that requires an extra round-trip.
+
+        Simpler and more reliable: represent the table as plain text paragraphs
+        in the current insert pass, then issue updateTableCellStyle in the
+        deferred pass after the whole document has been inserted.
+
+        Actually, the most robust approach for large documents is:
+        1. Use insertTable to create the grid structure.
+        2. The insertTable request inserts a structural element; following
+           requests insertText into specific cell locations.
+
+        Given the complexity of tracking cell indices without re-fetching, we use
+        the approach employed by the existing insert_table_in_document tool:
+        insert the table structure first, then fill cells via separate
+        insertText requests referencing the cell content locations by tracking
+        index arithmetic.
+
+        Google Docs insertTable inserts characters as follows (simplified):
+        - The table node itself counts as 1 index unit at table_start_index
+        - Each row node counts as 1 index unit
+        - Each cell node counts as 1 index unit
+        - Each cell's paragraph counts as 1 index unit (for the empty paragraph
+          placeholder)
+        The total insertion is: 1 + rows*(1 + cols*(2)) for an empty table
+        where each cell contains 1 empty paragraph (2 = cell open + paragraph).
+
+        Rather than replicate this brittle arithmetic we emit insertTable with
+        the full cell text in a single pass using the approach below.
+        """
+        num_rows = 1 + len(rows)  # header + data rows
+        num_cols = len(headers)
+        if num_cols == 0:
+            return
+
+        # Store the table_start_index BEFORE issuing insertTable
+        table_start = self.index
+
+        # Emit insertTable request — this creates an empty table structure
+        self.requests.append(
+            {
+                "insertTable": {
+                    "rows": num_rows,
+                    "columns": num_cols,
+                    "location": {"index": self.index},
+                }
+            }
+        )
+
+        # After insertTable the index advances by the table structural chars.
+        # Formula: 1 (table) + rows*(1 (row) + cols*(2 (cell + paragraph)))
+        # Plus a trailing newline the API appends after the table = 1
+        structural_chars = 1 + num_rows * (1 + num_cols * 2) + 1
+        self.index += structural_chars
+
+        # Now populate cells. We need to re-fetch document to get exact cell
+        # indices.  We can't do that here (no async context in builder).
+        # Instead, store fill info in the deferred list as a special sentinel.
+        all_rows = [headers] + rows
+        self._deferred.append(
+            {
+                "_fill_table": True,
+                "table_start_index": table_start,
+                "num_rows": num_rows,
+                "num_cols": num_cols,
+                "all_rows": all_rows,
+            }
+        )
+
+    def build(self) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+        """Return (insert_requests, deferred_requests).
+
+        insert_requests must be issued first; deferred_requests must be
+        issued after a re-fetch to get the actual cell indices.
+        """
+        return self.requests, self._deferred
+
+
+# ---------------------------------------------------------------------------
+# Async builder — uses Google Docs API to fill table cells and apply styles
+# ---------------------------------------------------------------------------
+
+
+async def _fill_tables_and_style(
+    svc: BaseService,
+    document_id: str,
+    deferred: list[dict[str, Any]],
+) -> None:
+    """For each deferred fill_table sentinel: re-fetch the doc, find the table,
+    fill all cells with text + apply borders + header styling."""
+    if not deferred:
+        return
+
+    fill_sentinels = [d for d in deferred if d.get("_fill_table")]
+    if not fill_sentinels:
+        return
+
+    # Re-fetch document to get actual indices after all insertions
+    doc = await svc._make_request(
+        "GET",
+        f"{DOCS_API_BASE}/documents/{document_id}",
+        params={"fields": "body(content(table,startIndex,endIndex))"},
+    )
+    body_content: list[dict[str, Any]] = doc.get("body", {}).get("content", [])
+
+    # Build a lookup: table_start_index → table element
+    table_by_start: dict[int, dict[str, Any]] = {}
+    for elem in body_content:
+        if "table" in elem:
+            si = elem.get("startIndex")
+            if si is not None:
+                table_by_start[si] = elem
+
+    for sentinel in fill_sentinels:
+        ts = sentinel["table_start_index"]
+        table_elem = table_by_start.get(ts)
+        if table_elem is None:
+            logger.warning("Could not find table at start_index=%d for cell fill", ts)
+            continue
+
+        all_rows: list[list[str]] = sentinel["all_rows"]
+        num_cols: int = sentinel["num_cols"]
+        num_rows: int = sentinel["num_rows"]
+
+        table_rows: list[dict[str, Any]] = table_elem.get("table", {}).get("tableRows", [])
+
+        # --- Phase 1: fill cell text ---
+        text_requests: list[dict[str, Any]] = []
+        for row_i, row_data in enumerate(all_rows):
+            if row_i >= len(table_rows):
+                break
+            cells = table_rows[row_i].get("tableCells", [])
+            for col_i, cell_text in enumerate(row_data[:num_cols]):
+                if col_i >= len(cells):
+                    break
+                if not cell_text.strip():
+                    continue
+                cell_content = cells[col_i].get("content", [])
+                if not cell_content:
+                    continue
+                # Insert into the first paragraph's start
+                para_start = cell_content[0].get("startIndex", 0)
+                if para_start:
+                    text_requests.append(
+                        {
+                            "insertText": {
+                                "location": {"index": para_start},
+                                "text": cell_text,
+                            }
+                        }
+                    )
+
+        if text_requests:
+            await _batch_update(svc, document_id, text_requests)
+
+        # --- Phase 2: apply borders + header styling ---
+        # Re-fetch table to get updated indices after text insertion
+        doc2 = await svc._make_request(
+            "GET",
+            f"{DOCS_API_BASE}/documents/{document_id}",
+            params={"fields": "body(content(table,startIndex,endIndex))"},
+        )
+        body2: list[dict[str, Any]] = doc2.get("body", {}).get("content", [])
+        # Find the table again (start_index is now different due to text insertion!)
+        # We find it by row/col count match near original position
+        target_table_elem = None
+        for elem2 in body2:
+            if "table" in elem2:
+                t2 = elem2["table"]
+                if t2.get("rows") == num_rows and t2.get("columns") == num_cols:
+                    target_table_elem = elem2
+                    break
+        if target_table_elem is None:
+            logger.warning(
+                "Could not re-locate table for styling (rows=%d, cols=%d)", num_rows, num_cols
+            )
+            continue
+
+        new_ts = target_table_elem.get("startIndex", ts)
+        style_requests: list[dict[str, Any]] = []
+
+        for row_i in range(num_rows):
+            is_header = row_i == 0
+            for col_i in range(num_cols):
+                cell_style: dict[str, Any] = {
+                    "borderTop": _TABLE_BORDER,
+                    "borderBottom": _TABLE_BORDER,
+                    "borderLeft": _TABLE_BORDER,
+                    "borderRight": _TABLE_BORDER,
+                }
+                field_keys = ["borderTop", "borderBottom", "borderLeft", "borderRight"]
+
+                if is_header:
+                    cell_style["backgroundColor"] = {"color": {"rgbColor": _HEADER_BG}}
+                    field_keys.append("backgroundColor")
+
+                style_requests.append(
+                    {
+                        "updateTableCellStyle": {
+                            "tableCellStyle": cell_style,
+                            "fields": ",".join(field_keys),
+                            "tableRange": {
+                                "tableCellLocation": {
+                                    "tableStartLocation": {"index": new_ts},
+                                    "rowIndex": row_i,
+                                    "columnIndex": col_i,
+                                },
+                                "rowSpan": 1,
+                                "columnSpan": 1,
+                            },
+                        }
+                    }
+                )
+
+        # Bold header text
+        table_rows2 = target_table_elem.get("table", {}).get("tableRows", [])
+        if table_rows2:
+            header_cells = table_rows2[0].get("tableCells", [])
+            for cell in header_cells:
+                content = cell.get("content", [])
+                if content:
+                    for para_elem in content:
+                        para = para_elem.get("paragraph", {})
+                        for el in para.get("elements", []):
+                            tr = el.get("textRun")
+                            if tr:
+                                run_start = el.get("startIndex", 0)
+                                run_end = el.get("endIndex", run_start)
+                                if run_start < run_end:
+                                    style_requests.append(
+                                        {
+                                            "updateTextStyle": {
+                                                "range": {
+                                                    "startIndex": run_start,
+                                                    "endIndex": run_end,
+                                                },
+                                                "textStyle": {"bold": True},
+                                                "fields": "bold",
+                                            }
+                                        }
+                                    )
+
+        if style_requests:
+            await _batch_update(svc, document_id, style_requests)
+
+
+async def _batch_update(
+    svc: BaseService,
+    document_id: str,
+    requests: list[dict[str, Any]],
+) -> None:
+    """Issue batchUpdate requests in safe chunks."""
+    url = f"{DOCS_API_BASE}/documents/{document_id}:batchUpdate"
+    for i in range(0, len(requests), _BATCH_CHUNK_SIZE):
+        chunk = requests[i : i + _BATCH_CHUNK_SIZE]
+        await svc._make_request("POST", url, json_data={"requests": chunk})
+
+
+# ---------------------------------------------------------------------------
+# Main handler
+# ---------------------------------------------------------------------------
+
+
+async def _markdown_file_to_doc(svc: BaseService, arguments: dict[str, Any]) -> dict[str, Any]:
+    """Convert a Markdown file (or inline content) to a Google Doc.
+
+    Steps:
+    1. Read the markdown (from file path or inline content).
+    2. Parse into blocks.
+    3. Build Docs API requests from the blocks.
+    4. Create or clear the target document.
+    5. Issue insert requests in chunks.
+    6. Post-process: fill table cells, apply borders, heading styles.
+    7. Return document id + webViewLink.
+    """
+    import secrets
+
+    markdown_file_path = arguments.get("markdown_file_path")
+    markdown_content = arguments.get("markdown_content")
+    title = arguments.get("title", "Untitled Document")
+    document_id: str | None = arguments.get("document_id")
+    folder_id: str | None = arguments.get("folder_id")
+
+    # --- 1. Read markdown ---
+    if markdown_file_path:
+        path = Path(markdown_file_path)
+        if not path.is_file():
+            raise FileNotFoundError(f"Markdown file not found: {markdown_file_path}")
+        markdown_content = path.read_text(encoding="utf-8")
+        logger.info("Read %d chars from %s", len(markdown_content), markdown_file_path)
+    elif not markdown_content:
+        raise ValueError("Either markdown_file_path or markdown_content must be provided")
+
+    # --- 2. Parse ---
+    blocks = parse_markdown(markdown_content)
+    logger.info("Parsed %d blocks from markdown", len(blocks))
+
+    # --- 3. Create or clear target document ---
+    if document_id:
+        # In-place update: clear the body then re-insert
+        doc = await svc._make_request(
+            "GET",
+            f"{DOCS_API_BASE}/documents/{document_id}",
+            params={"fields": "body(content(startIndex,endIndex))"},
+        )
+        body_content = doc.get("body", {}).get("content", [])
+        if body_content:
+            last_end = body_content[-1].get("endIndex", 1)
+            if last_end > 1:
+                # Delete everything except the trailing paragraph marker (index 0)
+                del_requests: list[dict[str, Any]] = [
+                    {
+                        "deleteContentRange": {
+                            "range": {
+                                "startIndex": 1,
+                                "endIndex": last_end - 1,
+                            }
+                        }
+                    }
+                ]
+                await _batch_update(svc, document_id, del_requests)
+        start_index = 1
+    else:
+        # Create new document
+        if folder_id:
+            import json
+
+            gdoc_metadata: dict[str, Any] = {
+                "name": title,
+                "mimeType": "application/vnd.google-apps.document",
+                "parents": [folder_id],
+            }
+            boundary = secrets.token_hex(16)
+            body_str = (
+                f"--{boundary}\r\n"
+                f"Content-Type: application/json; charset=UTF-8\r\n\r\n"
+                f"{json.dumps(gdoc_metadata)}\r\n"
+                f"--{boundary}\r\n"
+                f"Content-Type: text/plain\r\n\r\n"
+                f"\r\n--{boundary}--"
+            )
+            upload_url = "https://www.googleapis.com/upload/drive/v3/files?uploadType=multipart&supportsAllDrives=true"
+            response = await svc._make_raw_request(
+                "POST",
+                upload_url,
+                content=body_str.encode("utf-8"),
+                headers={"Content-Type": f"multipart/related; boundary={boundary}"},
+                timeout=60.0,
+            )
+            result = response.json()
+            document_id = result.get("id")
+        else:
+            create_resp = await svc._make_request(
+                "POST",
+                f"{DOCS_API_BASE}/documents",
+                json_data={"title": title},
+            )
+            document_id = create_resp.get("documentId")
+        start_index = 1
+
+    if not document_id:
+        raise RuntimeError("Failed to create or identify target document")
+
+    # --- 4. Build requests from blocks ---
+    builder = _DocBuilder(start_index=start_index)
+
+    for block in blocks:
+        btype = block["type"]
+        if btype == "heading":
+            builder.add_heading(block["level"], block["runs"])
+        elif btype == "paragraph":
+            builder.add_paragraph(block["runs"])
+        elif btype == "code":
+            builder.add_code_block(block["text"])
+        elif btype == "table":
+            builder.add_table(block["headers"], block["rows"])
+        elif btype == "bullet":
+            builder.add_bullet(block["depth"], block["runs"])
+        elif btype == "ordered":
+            builder.add_ordered(block["runs"], block.get("depth", 0))
+        elif btype == "blank":
+            builder.add_blank()
+        elif btype == "rule":
+            builder.add_rule()
+
+    insert_requests, deferred = builder.build()
+
+    # --- 5. Issue insert requests in chunks ---
+    if insert_requests:
+        await _batch_update(svc, document_id, insert_requests)
+        logger.info("Inserted %d requests into document %s", len(insert_requests), document_id)
+
+    # --- 6. Post-process: fill tables, apply borders + styles ---
+    await _fill_tables_and_style(svc, document_id, deferred)
+
+    # --- 7. Fetch webViewLink ---
+    file_meta = await svc._make_request(
+        "GET",
+        f"{DRIVE_API_BASE}/files/{document_id}",
+        params={"fields": "id,name,webViewLink,mimeType"},
+    )
+
+    return {
+        "status": "published" if not arguments.get("document_id") else "updated",
+        "document_id": document_id,
+        "title": file_meta.get("name", title),
+        "webViewLink": file_meta.get("webViewLink"),
+        "mimeType": file_meta.get("mimeType"),
+        "blocks_processed": len(blocks),
+        "requests_issued": len(insert_requests),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Registration
+# ---------------------------------------------------------------------------
+
+
+def get_handlers(svc: BaseService) -> dict[str, Any]:
+    """Return name->callable mapping for markdown_file_to_doc handler."""
+    return {
+        "markdown_file_to_doc": lambda args: _markdown_file_to_doc(svc, args),
+    }

--- a/src/gworkspace_mcp/server/services/docs/markdown_file.py
+++ b/src/gworkspace_mcp/server/services/docs/markdown_file.py
@@ -141,17 +141,29 @@ def _parse_inline_runs(text: str) -> list[dict[str, Any]]:
       - ``link``: URL string if this run is a hyperlink, else None
 
     Nested emphasis is not supported; the first matching token wins.
+
+    Emphasis rules (to avoid over-matching stray * and ~):
+    - ``*italic*`` / ``_italic_``: only when * or _ is adjacent to a
+      non-whitespace character on both sides (i.e. cannot start/end with space).
+    - ``~~strikethrough~~``: treated as literal (no Docs equivalent).
+    - ``~text~``: treated as literal.
     """
     runs: list[dict[str, Any]] = []
 
     # Pattern order matters: links before bold/italic so [text](...) is parsed
     # as a link rather than an italic fragment.
+    #
+    # Italic patterns use word-boundary-like anchors:
+    #   (?<!\s) before the closing delimiter — ensures the italic span does not
+    #   end with whitespace (prevents matching "* stray star").
+    #   (?!\s) after the opening delimiter — ensures the italic span does not
+    #   start with whitespace.
     pattern = re.compile(
         r"(?P<link>\[(?P<link_text>[^\]]+)\]\((?P<link_url>[^)]+)\))"
-        r"|(?P<bold>\*\*(?P<bold_text>.+?)\*\*)"
-        r"|(?P<bold2>__(?P<bold2_text>.+?)__)"
-        r"|(?P<italic>\*(?P<italic_text>.+?)\*)"
-        r"|(?P<italic2>_(?P<italic2_text>.+?)_)"
+        r"|(?P<bold>\*\*(?P<bold_text>\S.*?\S|\S)\*\*)"
+        r"|(?P<bold2>__(?P<bold2_text>\S.*?\S|\S)__)"
+        r"|(?P<italic>\*(?P<italic_text>\S.*?\S|\S)\*)"
+        r"|(?P<italic2>_(?P<italic2_text>\S.*?\S|\S)_)"
         r"|(?P<code>`(?P<code_text>[^`]+)`)"
     )
 
@@ -374,27 +386,56 @@ def parse_markdown(content: str) -> list[dict[str, Any]]:
             continue
 
         # ---- Paragraph (catch-all) ----
-        # Collect continuation lines (non-blank, not a new block)
-        para_lines: list[str] = [stripped]
+        # Collect continuation lines (non-blank, not a new block).
+        # Hard line breaks: a line ending in two or more spaces (or backslash)
+        # before its newline is a "hard break".  We split the paragraph into
+        # sub-lines at those boundaries and emit a "\n" within the paragraph
+        # rather than joining with a space.
+        # We accumulate (line_text, hard_break) pairs.
+        def _is_hard_break(raw_line: str) -> bool:
+            return raw_line.endswith("  ") or raw_line.endswith("\\")
+
+        para_raw_lines: list[tuple[str, bool]] = [(raw, _is_hard_break(raw))]
         i += 1
         while i < n:
-            next_raw = lines[i].rstrip()
-            if not next_raw:
+            next_raw = lines[i]
+            next_stripped = next_raw.rstrip()
+            if not next_stripped:
                 break
-            if re.match(r"^#{1,6}\s", next_raw):
+            if re.match(r"^#{1,6}\s", next_stripped):
                 break
-            if re.match(r"^(```|~~~)", next_raw):
+            if re.match(r"^(```|~~~)", next_stripped):
                 break
-            if re.match(r"^(\s*)[-*+]\s", next_raw):
+            if re.match(r"^(\s*)[-*+]\s", next_stripped):
                 break
-            if re.match(r"^(\s*)\d+[.)]\s", next_raw):
+            if re.match(r"^(\s*)\d+[.)]\s", next_stripped):
                 break
-            if re.match(r"^\s*[-*_]{3,}\s*$", next_raw):
+            if re.match(r"^\s*[-*_]{3,}\s*$", next_stripped):
                 break
-            para_lines.append(next_raw)
+            para_raw_lines.append((next_raw, _is_hard_break(next_raw)))
             i += 1
-        paragraph_text = " ".join(para_lines)
-        blocks.append({"type": "paragraph", "runs": _parse_inline_runs(paragraph_text)})
+
+        # Build paragraph runs, honouring hard breaks.
+        # A hard break inserts a literal "\n" run between sub-lines so the
+        # DocBuilder emits separate line-break characters in the same paragraph.
+        para_runs: list[dict[str, Any]] = []
+        for idx, (raw_line, is_hard) in enumerate(para_raw_lines):
+            line_text = raw_line.rstrip()  # strip trailing spaces / backslash
+            if line_text.endswith("\\"):
+                line_text = line_text[:-1]
+            para_runs.extend(_parse_inline_runs(line_text))
+            if is_hard and idx < len(para_raw_lines) - 1:
+                # Insert a hard line-break run (literal newline within paragraph)
+                para_runs.append(
+                    {"text": "\n", "bold": False, "italic": False, "code": False, "link": None}
+                )
+            elif idx < len(para_raw_lines) - 1:
+                # Soft continuation: join with a space
+                para_runs.append(
+                    {"text": " ", "bold": False, "italic": False, "code": False, "link": None}
+                )
+
+        blocks.append({"type": "paragraph", "runs": para_runs})
 
     return blocks
 
@@ -546,17 +587,33 @@ class _DocBuilder:
         _, end = self._insert_runs(runs)
         self._insert_text("\n")
         para_end = self.index
-        # Apply bullet list style
-        nesting_level = min(depth, 5)
+        # Apply bullet list style.
+        # Note: createParagraphBullets only accepts range + bulletPreset;
+        # nestingLevel is NOT a valid field and causes a 400 Bad Request.
+        # Indentation for nested bullets uses updateParagraphStyle below.
         self.requests.append(
             {
                 "createParagraphBullets": {
                     "range": {"startIndex": start, "endIndex": para_end},
                     "bulletPreset": "BULLET_DISC_CIRCLE_SQUARE",
-                    "nestingLevel": nesting_level,
                 }
             }
         )
+        # Indent nested bullets via paragraph indentation (18pt per level)
+        if depth > 0:
+            indent_pts = depth * 18.0
+            self.requests.append(
+                {
+                    "updateParagraphStyle": {
+                        "range": {"startIndex": start, "endIndex": para_end},
+                        "paragraphStyle": {
+                            "indentStart": {"magnitude": indent_pts, "unit": "PT"},
+                            "indentFirstLine": {"magnitude": indent_pts, "unit": "PT"},
+                        },
+                        "fields": "indentStart,indentFirstLine",
+                    }
+                }
+            )
         _ = end  # suppress unused warning
 
     def add_ordered(self, runs: list[dict[str, Any]], depth: int = 0) -> None:
@@ -564,16 +621,30 @@ class _DocBuilder:
         self._insert_runs(runs)
         self._insert_text("\n")
         para_end = self.index
-        nesting_level = min(depth, 5)
+        # Note: createParagraphBullets only accepts range + bulletPreset.
         self.requests.append(
             {
                 "createParagraphBullets": {
                     "range": {"startIndex": start, "endIndex": para_end},
                     "bulletPreset": "NUMBERED_DECIMAL_ALPHA_ROMAN",
-                    "nestingLevel": nesting_level,
                 }
             }
         )
+        # Indent nested ordered lists
+        if depth > 0:
+            indent_pts = depth * 18.0
+            self.requests.append(
+                {
+                    "updateParagraphStyle": {
+                        "range": {"startIndex": start, "endIndex": para_end},
+                        "paragraphStyle": {
+                            "indentStart": {"magnitude": indent_pts, "unit": "PT"},
+                            "indentFirstLine": {"magnitude": indent_pts, "unit": "PT"},
+                        },
+                        "fields": "indentStart,indentFirstLine",
+                    }
+                }
+            )
 
     def add_blank(self) -> None:
         self._insert_text("\n")
@@ -617,14 +688,14 @@ class _DocBuilder:
         insertText requests referencing the cell content locations by tracking
         index arithmetic.
 
-        Google Docs insertTable inserts characters as follows (simplified):
-        - The table node itself counts as 1 index unit at table_start_index
-        - Each row node counts as 1 index unit
-        - Each cell node counts as 1 index unit
-        - Each cell's paragraph counts as 1 index unit (for the empty paragraph
-          placeholder)
-        The total insertion is: 1 + rows*(1 + cols*(2)) for an empty table
-        where each cell contains 1 empty paragraph (2 = cell open + paragraph).
+        Google Docs insertTable inserts characters as follows (empirically verified):
+        - A pre-table paragraph is inserted before the table: 1 index unit
+        - The table node itself: 2 index units (open + structural close)
+        - Each row node: 1 index unit
+        - Each cell: 2 index units (cell open + cell paragraph)
+        Total structural advance = 1 + 2 + rows*(1 + cols*2)
+                                  = 3 + rows*(1 + cols*2)
+        Verified for: 1x1→6, 1x2→8, 2x2→13, 2x3→17, 3x4→30, 4x5→47.
 
         Rather than replicate this brittle arithmetic we emit insertTable with
         the full cell text in a single pass using the approach below.
@@ -648,10 +719,13 @@ class _DocBuilder:
             }
         )
 
-        # After insertTable the index advances by the table structural chars.
-        # Formula: 1 (table) + rows*(1 (row) + cols*(2 (cell + paragraph)))
-        # Plus a trailing newline the API appends after the table = 1
-        structural_chars = 1 + num_rows * (1 + num_cols * 2) + 1
+        # After insertTable the index advances by:
+        #   1 (pre-table paragraph the API inserts before the table)
+        #   + table_size where table_size = 2 + rows*(1 (row) + cols*(2 (cell + paragraph)))
+        # The table node itself accounts for 2 chars (open + close), not 1.
+        # Empirically verified: 2x3 table has size 16 = 2 + 2*(1 + 3*2).
+        table_size = 2 + num_rows * (1 + num_cols * 2)
+        structural_chars = 1 + table_size
         self.index += structural_chars
 
         # Now populate cells. We need to re-fetch document to get exact cell
@@ -704,29 +778,41 @@ async def _fill_tables_and_style(
     )
     body_content: list[dict[str, Any]] = doc.get("body", {}).get("content", [])
 
-    # Build a lookup: table_start_index → table element
-    table_by_start: dict[int, dict[str, Any]] = {}
-    for elem in body_content:
-        if "table" in elem:
-            si = elem.get("startIndex")
-            if si is not None:
-                table_by_start[si] = elem
+    # Collect tables in document order.  We match sentinels to tables by their
+    # sequential position (first sentinel → first table, etc.) rather than by
+    # start_index, because the stored table_start_index values come from the
+    # builder's pre-insertion estimates which do not account for the pre-table
+    # paragraph the API inserts, nor for index shifts caused by earlier inserts.
+    doc_tables: list[dict[str, Any]] = [elem for elem in body_content if "table" in elem]
 
-    for sentinel in fill_sentinels:
-        ts = sentinel["table_start_index"]
-        table_elem = table_by_start.get(ts)
-        if table_elem is None:
-            logger.warning("Could not find table at start_index=%d for cell fill", ts)
+    if len(doc_tables) != len(fill_sentinels):
+        logger.warning(
+            "Table count mismatch: doc has %d tables, builder has %d sentinels",
+            len(doc_tables),
+            len(fill_sentinels),
+        )
+
+    for sentinel_idx, sentinel in enumerate(fill_sentinels):
+        if sentinel_idx >= len(doc_tables):
+            logger.warning("No doc table for sentinel %d", sentinel_idx)
             continue
+        table_elem = doc_tables[sentinel_idx]
 
         all_rows: list[list[str]] = sentinel["all_rows"]
         num_cols: int = sentinel["num_cols"]
         num_rows: int = sentinel["num_rows"]
+        # Capture the table's actual start_index from the Phase 1 fetch.
+        table_actual_start: int = table_elem.get("startIndex", 0)
 
         table_rows: list[dict[str, Any]] = table_elem.get("table", {}).get("tableRows", [])
 
         # --- Phase 1: fill cell text ---
-        text_requests: list[dict[str, Any]] = []
+        # IMPORTANT: insertText at a given index shifts all subsequent indices
+        # forward by the length of the inserted text.  To avoid index drift we
+        # must insert cells in REVERSE document order (last cell first).  That
+        # way each insertion does not affect the indices of cells that still
+        # need to be filled.
+        cell_insertions: list[tuple[int, str]] = []  # (para_start_index, text)
         for row_i, row_data in enumerate(all_rows):
             if row_i >= len(table_rows):
                 break
@@ -742,42 +828,48 @@ async def _fill_tables_and_style(
                 # Insert into the first paragraph's start
                 para_start = cell_content[0].get("startIndex", 0)
                 if para_start:
-                    text_requests.append(
-                        {
-                            "insertText": {
-                                "location": {"index": para_start},
-                                "text": cell_text,
-                            }
-                        }
-                    )
+                    cell_insertions.append((para_start, cell_text))
+
+        # Sort descending by index so each insert does not shift later indices
+        cell_insertions.sort(key=lambda x: x[0], reverse=True)
+        text_requests: list[dict[str, Any]] = [
+            {
+                "insertText": {
+                    "location": {"index": para_start},
+                    "text": cell_text,
+                }
+            }
+            for para_start, cell_text in cell_insertions
+        ]
 
         if text_requests:
             await _batch_update(svc, document_id, text_requests)
 
         # --- Phase 2: apply borders + header styling ---
-        # Re-fetch table to get updated indices after text insertion
+        # Re-fetch the single table (by its sentinel index in doc order) to get
+        # updated cell indices after text was inserted into it.
         doc2 = await svc._make_request(
             "GET",
             f"{DOCS_API_BASE}/documents/{document_id}",
             params={"fields": "body(content(table,startIndex,endIndex))"},
         )
         body2: list[dict[str, Any]] = doc2.get("body", {}).get("content", [])
-        # Find the table again (start_index is now different due to text insertion!)
-        # We find it by row/col count match near original position
-        target_table_elem = None
-        for elem2 in body2:
-            if "table" in elem2:
-                t2 = elem2["table"]
-                if t2.get("rows") == num_rows and t2.get("columns") == num_cols:
-                    target_table_elem = elem2
-                    break
+        # Tables in doc order; pick the same sentinel_idx-th table.
+        # After inserting text into cells the table shifts forward, so we
+        # can no longer rely on startIndex.  The table's relative position
+        # (its ordinal in the document) is stable.
+        doc_tables2 = [e for e in body2 if "table" in e]
+        if sentinel_idx >= len(doc_tables2):
+            logger.warning("Could not re-locate table %d for styling after text fill", sentinel_idx)
+            continue
+        target_table_elem = doc_tables2[sentinel_idx]
         if target_table_elem is None:
             logger.warning(
                 "Could not re-locate table for styling (rows=%d, cols=%d)", num_rows, num_cols
             )
             continue
 
-        new_ts = target_table_elem.get("startIndex", ts)
+        new_ts = target_table_elem.get("startIndex", table_actual_start)
         style_requests: list[dict[str, Any]] = []
 
         for row_i in range(num_rows):

--- a/src/gworkspace_mcp/server/services/docs/table_format.py
+++ b/src/gworkspace_mcp/server/services/docs/table_format.py
@@ -260,9 +260,18 @@ def _build_border_requests(
 def _build_header_requests(
     table_start_index: int,
     num_cols: int,
-    header_cell_start_indices: list[int],
+    header_cell_ranges: list[tuple[int, int]],
 ) -> list[dict[str, Any]]:
-    """Build requests for header row: light-grey background + bold text."""
+    """Build requests for header row: light-grey background + bold text.
+
+    Why: Applies bold to the *full* text of each header cell, not just its
+    first character.  The caller provides (startIndex, endIndex) pairs that
+    span the entire paragraph element so every character is bolded.
+    What: Emits one updateTableCellStyle (background) per column and one
+    updateTextStyle (bold) per non-empty header cell.
+    Test: Construct a doc body with a 2-col table whose header cells contain
+    multi-char text; assert each bold range has endIndex > startIndex + 1.
+    """
     requests: list[dict[str, Any]] = []
 
     # Background colour on each header cell
@@ -288,13 +297,13 @@ def _build_header_requests(
             }
         )
 
-    # Bold text on first paragraph segment of each header cell
-    for start_idx in header_cell_start_indices:
-        if start_idx > 0:
+    # Bold the full text of each header cell using (startIndex, endIndex) ranges
+    for start_idx, end_idx in header_cell_ranges:
+        if start_idx > 0 and end_idx > start_idx:
             requests.append(
                 {
                     "updateTextStyle": {
-                        "range": {"startIndex": start_idx, "endIndex": start_idx + 1},
+                        "range": {"startIndex": start_idx, "endIndex": end_idx},
                         "textStyle": {"bold": True},
                         "fields": "bold",
                     }
@@ -330,8 +339,17 @@ def _build_column_width_requests(
 def _find_header_cell_indices(
     body_content: list[dict[str, Any]],
     table_start_index: int,
-) -> list[int]:
-    """Return the content start index of each cell in row 0 for the given table."""
+) -> list[tuple[int, int]]:
+    """Return (startIndex, endIndex) pairs for the first paragraph of each cell in row 0.
+
+    Why: Callers need both boundaries to bold the *full* header-cell text rather
+    than just its first character.
+    What: Walks body content to find the table at table_start_index, then for
+    each cell in the header row returns (content[0].startIndex, content[0].endIndex).
+    Test: Build a minimal body_content dict with a table at a known startIndex
+    containing 2-char and 5-char header cells; assert returned endIndex values
+    equal startIndex + len(cell_text) + 1 (the trailing newline char).
+    """
     for element in body_content:
         tbl = element.get("table")
         if tbl is None:
@@ -341,14 +359,16 @@ def _find_header_cell_indices(
         rows = tbl.get("tableRows", [])
         if not rows:
             return []
-        header_indices: list[int] = []
+        header_ranges: list[tuple[int, int]] = []
         for cell in rows[0].get("tableCells", []):
             content = cell.get("content", [])
             if content:
-                header_indices.append(content[0].get("startIndex", 0))
+                start = content[0].get("startIndex", 0)
+                end = content[0].get("endIndex", start)
+                header_ranges.append((start, end))
             else:
-                header_indices.append(0)
-        return header_indices
+                header_ranges.append((0, 0))
+        return header_ranges
     return []
 
 
@@ -421,8 +441,8 @@ async def _format_document_tables(svc: BaseService, arguments: dict[str, Any]) -
         #    For the first table pass we can reuse body_content; subsequent tables
         #    may have been modified by prior batches (but only style/width, not text
         #    positions, so indices remain stable).
-        header_start_indices = _find_header_cell_indices(body_content, tsi)
-        all_requests.extend(_build_header_requests(tsi, num_cols, header_start_indices))
+        header_cell_ranges = _find_header_cell_indices(body_content, tsi)
+        all_requests.extend(_build_header_requests(tsi, num_cols, header_cell_ranges))
 
         # 3. Content-aware column widths
         widths = compute_content_aware_widths(cell_texts, usable_width)
@@ -436,7 +456,7 @@ async def _format_document_tables(svc: BaseService, arguments: dict[str, Any]) -
 
         tables_processed += 1
         logger.debug(
-            "format_document_tables: table at index %d formatted " "(%d rows x %d cols, widths=%s)",
+            "format_document_tables: table at index %d formatted (%d rows x %d cols, widths=%s)",
             tsi,
             num_rows,
             num_cols,

--- a/src/gworkspace_mcp/server/services/docs/table_format.py
+++ b/src/gworkspace_mcp/server/services/docs/table_format.py
@@ -1,0 +1,460 @@
+"""format_document_tables: post-processing pass to add borders + content-aware widths.
+
+Walks all tables in a Google Doc and for each table:
+1. Applies visible borders to every cell (1pt solid, all four sides).
+2. Styles the first (header) row: bold text + light-grey shading.
+3. Sets per-column widths proportional to cell-content length, so text-heavy
+   columns receive more space and narrow numeric/code columns stay compact.
+
+Width algorithm (pure, testable via compute_content_aware_widths):
+  - For each column compute weight = min(max_chars_in_column, CAP) with CAP=60.
+  - Distribute usable_width across columns proportional to weights.
+  - Clamp each column to MIN_COL (40pt) and renormalise so widths sum to usable_width.
+  - usable_width is read from documentStyle (page_width - left_margin - right_margin),
+    falling back to 468pt (US Letter with 1-inch margins).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any
+
+from mcp.types import Tool
+
+from gworkspace_mcp.server.constants import DOCS_API_BASE
+
+if TYPE_CHECKING:
+    from gworkspace_mcp.server.base import BaseService
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Width algorithm constants
+# ---------------------------------------------------------------------------
+_CONTENT_CAP: int = 60  # max chars used for any single column weight
+_MIN_COL_PT: float = 40.0  # hard minimum column width in points
+_FALLBACK_WIDTH: float = 468.0  # US Letter minus 1-inch margins on each side
+
+# Border style: 1pt solid dark-grey
+_BORDER_COLOR: dict[str, float] = {"red": 0.4, "green": 0.4, "blue": 0.4}
+_BORDER_WIDTH_PT: float = 1.0
+
+# Header row styling
+_HEADER_BG: dict[str, float] = {"red": 0.9, "green": 0.9, "blue": 0.9}  # light grey
+
+# ---------------------------------------------------------------------------
+# Tool definition
+# ---------------------------------------------------------------------------
+
+TOOLS: list[Tool] = [
+    Tool(
+        name="format_document_tables",
+        description=(
+            "Post-processing pass: walk ALL tables in a Google Doc and apply "
+            "(1) visible 1pt solid borders on every cell, a bold+light-grey "
+            "header row, and (2) content-aware column widths so text-heavy "
+            "columns are wider than narrow numeric columns. "
+            "Usable page width is read from the document's documentStyle; "
+            "falls back to 468pt (US Letter, 1-inch margins). "
+            "Idempotent — safe to call multiple times."
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "document_id": {
+                    "type": "string",
+                    "description": "Google Doc ID",
+                },
+                "account": {
+                    "type": "string",
+                    "description": (
+                        "Google account profile to use. "
+                        "Omit to use the default account. "
+                        "Use 'workspace accounts list' to see available profiles."
+                    ),
+                },
+            },
+            "required": ["document_id"],
+        },
+    ),
+]
+
+# ---------------------------------------------------------------------------
+# Pure helper: content-aware column width algorithm
+# ---------------------------------------------------------------------------
+
+
+def compute_content_aware_widths(
+    table_cells: list[list[str]],
+    usable_width: float,
+    cap: int = _CONTENT_CAP,
+    min_col_pt: float = _MIN_COL_PT,
+) -> list[float]:
+    """Return content-proportional column widths in PT.
+
+    Parameters
+    ----------
+    table_cells:
+        2-D list of cell text strings (row-major). May include the header row.
+    usable_width:
+        Available horizontal space in PT.
+    cap:
+        Maximum character count contribution per column (prevents one very
+        long cell from dominating). Default 60.
+    min_col_pt:
+        Hard minimum column width in PT. Default 40.
+
+    Returns
+    -------
+    list[float]
+        One width per column.  Widths sum to ``usable_width``.
+        Returns an empty list when ``table_cells`` is empty.
+    """
+    if not table_cells:
+        return []
+
+    num_cols = max(len(row) for row in table_cells)
+    if num_cols == 0:
+        return []
+
+    # Compute per-column weight = min(max_chars, cap), at least 1
+    weights: list[float] = []
+    for col_idx in range(num_cols):
+        max_chars = 1
+        for row in table_cells:
+            if col_idx < len(row):
+                max_chars = max(max_chars, len(row[col_idx]))
+        weights.append(float(min(max_chars, cap)))
+
+    # Iterative min-clamp allocation:
+    # Columns whose proportional share < min_col_pt receive min_col_pt exactly.
+    # Their "reserved" width is subtracted from the budget, and the remainder is
+    # redistributed proportionally among the unclamped columns.  Repeat until stable.
+    final: list[float] = [0.0] * num_cols
+    clamped_mask: list[bool] = [False] * num_cols
+    remaining_width = usable_width
+
+    for _ in range(num_cols + 1):  # at most num_cols iterations to reach stability
+        free_weight = sum(w for i, w in enumerate(weights) if not clamped_mask[i])
+        if free_weight <= 0:
+            break
+
+        # Provisional proportional allocation for free (unclamped) columns
+        newly_clamped = False
+        for i in range(num_cols):
+            if clamped_mask[i]:
+                continue
+            provisional = remaining_width * weights[i] / free_weight
+            if provisional < min_col_pt:
+                final[i] = min_col_pt
+                clamped_mask[i] = True
+                remaining_width -= min_col_pt
+                newly_clamped = True
+
+        if not newly_clamped:
+            # Stable: assign proportional widths to remaining free columns
+            for i in range(num_cols):
+                if not clamped_mask[i]:
+                    final[i] = remaining_width * weights[i] / free_weight
+            break
+
+    # Handle any columns still at 0 (edge case: all remaining budget consumed)
+    for i in range(num_cols):
+        if final[i] == 0.0:
+            final[i] = min_col_pt
+
+    # Renormalise unclamped columns to ensure sum == usable_width exactly,
+    # while never reducing clamped columns below their minimum.
+    total_clamped = sum(final[i] for i in range(num_cols) if clamped_mask[i])
+    free_cols = [i for i in range(num_cols) if not clamped_mask[i]]
+    if free_cols:
+        remaining_for_free = usable_width - total_clamped
+        current_free_total = sum(final[i] for i in free_cols)
+        if current_free_total > 0 and remaining_for_free > 0:
+            scale = remaining_for_free / current_free_total
+            for i in free_cols:
+                final[i] = final[i] * scale
+
+    return final
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _extract_cell_text(cell: dict[str, Any]) -> str:
+    """Return the concatenated plain text from a table cell."""
+    parts: list[str] = []
+    for content_elem in cell.get("content", []):
+        paragraph = content_elem.get("paragraph")
+        if not paragraph:
+            continue
+        for elem in paragraph.get("elements", []):
+            text_run = elem.get("textRun")
+            if text_run:
+                parts.append(text_run.get("content", ""))
+    return "".join(parts).strip()
+
+
+def _get_usable_width(doc: dict[str, Any]) -> float:
+    """Extract usable page width from documentStyle, or return fallback."""
+    doc_style = doc.get("documentStyle", {})
+    page_size = doc_style.get("pageSize", {})
+    page_width_obj = page_size.get("width", {})
+    margin_left_obj = doc_style.get("marginLeft", {})
+    margin_right_obj = doc_style.get("marginRight", {})
+
+    page_width = page_width_obj.get("magnitude", 0.0)
+    margin_left = margin_left_obj.get("magnitude", 0.0)
+    margin_right = margin_right_obj.get("magnitude", 0.0)
+
+    if page_width > 0 and (margin_left + margin_right) < page_width:
+        return page_width - margin_left - margin_right
+
+    return _FALLBACK_WIDTH
+
+
+def _build_border_requests(
+    table_start_index: int,
+    num_rows: int,
+    num_cols: int,
+) -> list[dict[str, Any]]:
+    """Build updateTableCellStyle requests for 1pt solid borders on all cells."""
+    border_obj: dict[str, Any] = {
+        "color": {"color": {"rgbColor": _BORDER_COLOR}},
+        "width": {"magnitude": _BORDER_WIDTH_PT, "unit": "PT"},
+        "dashStyle": "SOLID",
+    }
+    border_fields = "borderTop,borderBottom,borderLeft,borderRight"
+
+    requests: list[dict[str, Any]] = []
+    for row_idx in range(num_rows):
+        for col_idx in range(num_cols):
+            cell_style: dict[str, Any] = {
+                "borderTop": border_obj,
+                "borderBottom": border_obj,
+                "borderLeft": border_obj,
+                "borderRight": border_obj,
+            }
+            requests.append(
+                {
+                    "updateTableCellStyle": {
+                        "tableCellStyle": cell_style,
+                        "fields": border_fields,
+                        "tableRange": {
+                            "tableCellLocation": {
+                                "tableStartLocation": {"index": table_start_index},
+                                "rowIndex": row_idx,
+                                "columnIndex": col_idx,
+                            },
+                            "rowSpan": 1,
+                            "columnSpan": 1,
+                        },
+                    }
+                }
+            )
+    return requests
+
+
+def _build_header_requests(
+    table_start_index: int,
+    num_cols: int,
+    header_cell_start_indices: list[int],
+) -> list[dict[str, Any]]:
+    """Build requests for header row: light-grey background + bold text."""
+    requests: list[dict[str, Any]] = []
+
+    # Background colour on each header cell
+    for col_idx in range(num_cols):
+        cell_style: dict[str, Any] = {
+            "backgroundColor": {"color": {"rgbColor": _HEADER_BG}},
+        }
+        requests.append(
+            {
+                "updateTableCellStyle": {
+                    "tableCellStyle": cell_style,
+                    "fields": "backgroundColor",
+                    "tableRange": {
+                        "tableCellLocation": {
+                            "tableStartLocation": {"index": table_start_index},
+                            "rowIndex": 0,
+                            "columnIndex": col_idx,
+                        },
+                        "rowSpan": 1,
+                        "columnSpan": 1,
+                    },
+                }
+            }
+        )
+
+    # Bold text on first paragraph segment of each header cell
+    for start_idx in header_cell_start_indices:
+        if start_idx > 0:
+            requests.append(
+                {
+                    "updateTextStyle": {
+                        "range": {"startIndex": start_idx, "endIndex": start_idx + 1},
+                        "textStyle": {"bold": True},
+                        "fields": "bold",
+                    }
+                }
+            )
+
+    return requests
+
+
+def _build_column_width_requests(
+    table_start_index: int,
+    widths: list[float],
+) -> list[dict[str, Any]]:
+    """Build updateTableColumnProperties requests for fixed column widths."""
+    requests: list[dict[str, Any]] = []
+    for col_idx, width_pt in enumerate(widths):
+        requests.append(
+            {
+                "updateTableColumnProperties": {
+                    "tableStartLocation": {"index": table_start_index},
+                    "columnIndices": [col_idx],
+                    "tableColumnProperties": {
+                        "widthType": "FIXED_WIDTH",
+                        "width": {"magnitude": width_pt, "unit": "PT"},
+                    },
+                    "fields": "widthType,width",
+                }
+            }
+        )
+    return requests
+
+
+def _find_header_cell_indices(
+    body_content: list[dict[str, Any]],
+    table_start_index: int,
+) -> list[int]:
+    """Return the content start index of each cell in row 0 for the given table."""
+    for element in body_content:
+        tbl = element.get("table")
+        if tbl is None:
+            continue
+        if element.get("startIndex") != table_start_index:
+            continue
+        rows = tbl.get("tableRows", [])
+        if not rows:
+            return []
+        header_indices: list[int] = []
+        for cell in rows[0].get("tableCells", []):
+            content = cell.get("content", [])
+            if content:
+                header_indices.append(content[0].get("startIndex", 0))
+            else:
+                header_indices.append(0)
+        return header_indices
+    return []
+
+
+# ---------------------------------------------------------------------------
+# Handler
+# ---------------------------------------------------------------------------
+
+_BATCH_CHUNK = 200  # stay well under the 2000-request batchUpdate limit
+
+
+async def _format_document_tables(svc: BaseService, arguments: dict[str, Any]) -> dict[str, Any]:
+    document_id: str = arguments["document_id"]
+    doc_url = f"{DOCS_API_BASE}/documents/{document_id}"
+    batch_url = f"{DOCS_API_BASE}/documents/{document_id}:batchUpdate"
+
+    # Fetch the document once
+    doc = await svc._make_request("GET", doc_url)
+
+    usable_width = _get_usable_width(doc)
+    body_content: list[dict[str, Any]] = doc.get("body", {}).get("content", [])
+
+    # Gather all tables
+    tables: list[dict[str, Any]] = []
+    for element in body_content:
+        tbl = element.get("table")
+        if tbl is None:
+            continue
+        t_rows = tbl.get("tableRows", [])
+        t_num_rows = len(t_rows)
+        t_num_cols = max((len(r.get("tableCells", [])) for r in t_rows), default=0)
+        if t_num_rows == 0 or t_num_cols == 0:
+            continue
+
+        # Collect cell texts for width computation
+        t_cell_texts: list[list[str]] = []
+        for row in t_rows:
+            t_cell_texts.append([_extract_cell_text(cell) for cell in row.get("tableCells", [])])
+
+        tables.append(
+            {
+                "start_index": element["startIndex"],
+                "num_rows": t_num_rows,
+                "num_cols": t_num_cols,
+                "cell_texts": t_cell_texts,
+            }
+        )
+
+    if not tables:
+        return {
+            "status": "no_tables_found",
+            "document_id": document_id,
+            "tables_processed": 0,
+        }
+
+    total_requests_sent = 0
+    tables_processed = 0
+
+    for table_info in tables:
+        tsi: int = table_info["start_index"]
+        num_rows: int = table_info["num_rows"]
+        num_cols: int = table_info["num_cols"]
+        cell_texts: list[list[str]] = table_info["cell_texts"]
+
+        all_requests: list[dict[str, Any]] = []
+
+        # 1. Borders on all cells
+        all_requests.extend(_build_border_requests(tsi, num_rows, num_cols))
+
+        # 2. Header row styling — need fresh doc body to get cell content indices
+        #    For the first table pass we can reuse body_content; subsequent tables
+        #    may have been modified by prior batches (but only style/width, not text
+        #    positions, so indices remain stable).
+        header_start_indices = _find_header_cell_indices(body_content, tsi)
+        all_requests.extend(_build_header_requests(tsi, num_cols, header_start_indices))
+
+        # 3. Content-aware column widths
+        widths = compute_content_aware_widths(cell_texts, usable_width)
+        all_requests.extend(_build_column_width_requests(tsi, widths))
+
+        # Send in chunks to respect batchUpdate size limits
+        for chunk_start in range(0, len(all_requests), _BATCH_CHUNK):
+            chunk = all_requests[chunk_start : chunk_start + _BATCH_CHUNK]
+            await svc._make_request("POST", batch_url, json_data={"requests": chunk})
+            total_requests_sent += len(chunk)
+
+        tables_processed += 1
+        logger.debug(
+            "format_document_tables: table at index %d formatted " "(%d rows x %d cols, widths=%s)",
+            tsi,
+            num_rows,
+            num_cols,
+            [round(w, 1) for w in widths],
+        )
+
+    return {
+        "status": "formatted",
+        "document_id": document_id,
+        "document_url": f"https://docs.google.com/document/d/{document_id}/edit",
+        "tables_processed": tables_processed,
+        "usable_width_pt": usable_width,
+        "total_requests_sent": total_requests_sent,
+    }
+
+
+def get_handlers(svc: BaseService) -> dict[str, Any]:
+    """Return name->callable mapping for table-format handlers."""
+    return {
+        "format_document_tables": lambda args: _format_document_tables(svc, args),
+    }

--- a/src/gworkspace_mcp/skills/gworkspace-mcp/SKILL.md
+++ b/src/gworkspace_mcp/skills/gworkspace-mcp/SKILL.md
@@ -155,7 +155,7 @@ has:attachment larger:5M is:unread label:important
 
 **Drive query syntax:** `name contains 'report' and mimeType = 'application/pdf' and modifiedTime > '2024-01-01'`
 
-### Docs (16 tools)
+### Docs (17 tools)
 
 | Tool | Key Parameters | Description |
 |------|---------------|-------------|
@@ -164,6 +164,7 @@ has:attachment larger:5M is:unread label:important
 | `append_to_document` | `document_id`, `content` | Add text at end |
 | `upload_markdown_as_doc` | `markdown_content`, `title`, `folder_id` | Markdown → Google Doc |
 | `publish_markdown_to_doc` | `document_id`, `markdown_content` | Replace doc with markdown |
+| `markdown_file_to_doc` | `markdown_file_path`, `title`, `document_id?`, `folder_id?`, `account?` | **Robust** Markdown file → Google Doc; fixes truncation on large docs, adds real table borders, supports in-place update via `document_id` |
 | `list_document_comments` | `document_id` | All comments |
 | `add_document_comment` | `document_id`, `content`, `anchor` | New comment |
 | `reply_to_comment` | `document_id`, `comment_id`, `content` | Reply to comment |

--- a/src/gworkspace_mcp/skills/gworkspace-mcp/SKILL.md
+++ b/src/gworkspace_mcp/skills/gworkspace-mcp/SKILL.md
@@ -155,7 +155,7 @@ has:attachment larger:5M is:unread label:important
 
 **Drive query syntax:** `name contains 'report' and mimeType = 'application/pdf' and modifiedTime > '2024-01-01'`
 
-### Docs (17 tools)
+### Docs (18 tools)
 
 | Tool | Key Parameters | Description |
 |------|---------------|-------------|
@@ -165,6 +165,7 @@ has:attachment larger:5M is:unread label:important
 | `upload_markdown_as_doc` | `markdown_content`, `title`, `folder_id` | Markdown → Google Doc |
 | `publish_markdown_to_doc` | `document_id`, `markdown_content` | Replace doc with markdown |
 | `markdown_file_to_doc` | `markdown_file_path`, `title`, `document_id?`, `folder_id?`, `account?` | **Robust** Markdown file → Google Doc; fixes truncation on large docs, adds real table borders, supports in-place update via `document_id` |
+| `format_document_tables` | `document_id`, `account?` | Post-process all tables in a doc: applies 1pt solid borders, bold+light-grey header row, and content-aware column widths; idempotent |
 | `list_document_comments` | `document_id` | All comments |
 | `add_document_comment` | `document_id`, `content`, `anchor` | New comment |
 | `reply_to_comment` | `document_id`, `comment_id`, `content` | Reply to comment |

--- a/tests/unit/test_format_document_tables.py
+++ b/tests/unit/test_format_document_tables.py
@@ -1,0 +1,183 @@
+"""Unit tests for format_document_tables — pure width-algorithm coverage.
+
+Tests verify (offline, no API calls):
+  (a) widths sum to usable_width (within floating-point tolerance)
+  (b) the column with the longest max-cell-text receives the largest width
+  (c) min-clamp (40pt) is respected for all columns
+  (d) edge cases: single column, equal columns, empty rows, cap enforcement
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from gworkspace_mcp.server.services.docs.table_format import (
+    _FALLBACK_WIDTH,
+    _MIN_COL_PT,
+    TOOLS,
+    compute_content_aware_widths,
+)
+
+USABLE = 468.0  # standard US-Letter usable width
+
+
+# ---------------------------------------------------------------------------
+# Tool registration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestFormatDocumentTablesTool:
+    def test_tool_registered(self) -> None:
+        names = [t.name for t in TOOLS]
+        assert "format_document_tables" in names
+
+    def test_tool_description_nonempty(self) -> None:
+        tool = next(t for t in TOOLS if t.name == "format_document_tables")
+        assert len(tool.description) > 20
+
+    def test_schema_requires_document_id(self) -> None:
+        tool = next(t for t in TOOLS if t.name == "format_document_tables")
+        assert "document_id" in tool.inputSchema.get("required", [])
+
+    def test_schema_has_account(self) -> None:
+        tool = next(t for t in TOOLS if t.name == "format_document_tables")
+        assert "account" in tool.inputSchema.get("properties", {})
+
+
+# ---------------------------------------------------------------------------
+# Width algorithm: compute_content_aware_widths
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestComputeContentAwareWidths:
+    # ------------------------------------------------------------------
+    # (a) Widths sum to usable_width
+    # ------------------------------------------------------------------
+
+    def test_widths_sum_to_usable_width_basic(self) -> None:
+        data = [
+            ["Work Type", "Description", "%"],
+            ["Feature", "New user-facing functionality", "45"],
+            ["Bug Fix", "Defect resolution", "30"],
+        ]
+        widths = compute_content_aware_widths(data, USABLE)
+        assert abs(sum(widths) - USABLE) < 0.5, f"sum={sum(widths)} != {USABLE}"
+
+    def test_widths_sum_to_usable_width_single_col(self) -> None:
+        data = [["Header"], ["Some text"], ["More"]]
+        widths = compute_content_aware_widths(data, USABLE)
+        assert len(widths) == 1
+        assert abs(widths[0] - USABLE) < 0.5
+
+    def test_widths_sum_to_usable_width_many_cols(self) -> None:
+        data = [["A", "BB", "CCC", "DDDD", "EEEEE", "FFFFFF"]]
+        widths = compute_content_aware_widths(data, USABLE)
+        assert abs(sum(widths) - USABLE) < 0.5
+
+    def test_widths_sum_with_custom_usable_width(self) -> None:
+        data = [["Col1", "Col2"], ["abc", "x"]]
+        usable = 300.0
+        widths = compute_content_aware_widths(data, usable)
+        assert abs(sum(widths) - usable) < 0.5
+
+    # ------------------------------------------------------------------
+    # (b) Longest column gets the largest width
+    # ------------------------------------------------------------------
+
+    def test_longest_column_gets_largest_width(self) -> None:
+        """'Work Type' column has much longer text than '%' column."""
+        data = [
+            ["Work Type", "% Commits"],
+            ["Feature Development & new capability work", "45%"],
+            ["Bug Fix and Maintenance", "30%"],
+            ["Technical Debt Reduction", "25%"],
+        ]
+        widths = compute_content_aware_widths(data, USABLE)
+        # col 0 ("Work Type") has much longer cells than col 1 ("% Commits")
+        assert (
+            widths[0] > widths[1]
+        ), f"Expected col0 ({widths[0]:.1f}pt) > col1 ({widths[1]:.1f}pt)"
+
+    def test_widest_col_in_multi_col_table(self) -> None:
+        """The column with the globally longest cell should be widest."""
+        data = [
+            ["Short", "Very long description that goes on and on", "Num"],
+            ["A", "Another moderately long description here", "1"],
+            ["B", "Yet another entry", "2"],
+        ]
+        widths = compute_content_aware_widths(data, USABLE)
+        max_idx = widths.index(max(widths))
+        assert max_idx == 1, f"Expected column 1 to be widest, got {max_idx}"
+
+    def test_equal_columns_get_equal_widths(self) -> None:
+        """When all columns have identical content lengths, widths should be equal."""
+        data = [["ABC", "DEF", "GHI"], ["123", "456", "789"]]
+        widths = compute_content_aware_widths(data, USABLE)
+        assert len({round(w, 1) for w in widths}) == 1, f"Expected equal widths, got {widths}"
+
+    # ------------------------------------------------------------------
+    # (c) Minimum clamp respected
+    # ------------------------------------------------------------------
+
+    def test_min_clamp_respected(self) -> None:
+        """Even a one-character column must be >= _MIN_COL_PT."""
+        data = [["A" * 100, "x"], ["B" * 100, "y"]]
+        widths = compute_content_aware_widths(data, USABLE)
+        for i, w in enumerate(widths):
+            assert w >= _MIN_COL_PT, f"col {i} width {w:.1f}pt < min {_MIN_COL_PT}pt"
+
+    def test_custom_min_clamp(self) -> None:
+        custom_min = 50.0
+        data = [["LongText" * 10, "x"]]
+        widths = compute_content_aware_widths(data, USABLE, min_col_pt=custom_min)
+        for w in widths:
+            assert w >= custom_min
+
+    # ------------------------------------------------------------------
+    # (d) Cap enforcement
+    # ------------------------------------------------------------------
+
+    def test_cap_prevents_one_column_domination(self) -> None:
+        """A cell with 1000 chars should be treated the same as one with cap chars."""
+        data_capped = [["X" * 200, "ShortCol"]]
+        data_exact = [["X" * 60, "ShortCol"]]  # 60 == default CAP
+        widths_capped = compute_content_aware_widths(data_capped, USABLE, cap=60)
+        widths_exact = compute_content_aware_widths(data_exact, USABLE, cap=60)
+        assert (
+            abs(widths_capped[0] - widths_exact[0]) < 0.5
+        ), "Cap should make 200-char and 60-char columns produce equal weight"
+
+    def test_cap_respected_for_all_cols(self) -> None:
+        data = [["X" * 500, "Y" * 500, "Z" * 500]]
+        widths = compute_content_aware_widths(data, USABLE, cap=60)
+        # All three should be equal (all exceed cap)
+        assert abs(widths[0] - widths[1]) < 0.5
+        assert abs(widths[1] - widths[2]) < 0.5
+
+    # ------------------------------------------------------------------
+    # Edge cases
+    # ------------------------------------------------------------------
+
+    def test_empty_table_returns_empty(self) -> None:
+        widths = compute_content_aware_widths([], USABLE)
+        assert widths == []
+
+    def test_single_row_single_col(self) -> None:
+        widths = compute_content_aware_widths([["text"]], USABLE)
+        assert len(widths) == 1
+        assert abs(widths[0] - USABLE) < 0.5
+
+    def test_rows_with_varying_col_counts(self) -> None:
+        """Ragged rows — num_cols taken from the widest row."""
+        data = [["A", "B", "C"], ["X"]]  # row 1 only has 1 cell
+        widths = compute_content_aware_widths(data, USABLE)
+        assert len(widths) == 3
+        assert abs(sum(widths) - USABLE) < 0.5
+
+    def test_fallback_width_constant(self) -> None:
+        assert _FALLBACK_WIDTH == 468.0
+
+    def test_min_col_pt_constant(self) -> None:
+        assert _MIN_COL_PT == 40.0

--- a/tests/unit/test_format_document_tables.py
+++ b/tests/unit/test_format_document_tables.py
@@ -15,6 +15,8 @@ from gworkspace_mcp.server.services.docs.table_format import (
     _FALLBACK_WIDTH,
     _MIN_COL_PT,
     TOOLS,
+    _build_header_requests,
+    _find_header_cell_indices,
     compute_content_aware_widths,
 )
 
@@ -181,3 +183,93 @@ class TestComputeContentAwareWidths:
 
     def test_min_col_pt_constant(self) -> None:
         assert _MIN_COL_PT == 40.0
+
+
+# ---------------------------------------------------------------------------
+# Header bold-range tests (finding: endIndex must cover full cell text)
+# ---------------------------------------------------------------------------
+
+
+def _make_body_content(
+    table_start: int,
+    header_cells: list[tuple[int, int]],
+) -> list[dict]:
+    """Build a minimal body_content list with one table at table_start.
+
+    Each item in header_cells is (start_index, end_index) for that cell's
+    first paragraph content element.
+    """
+    cells = []
+    for start, end in header_cells:
+        cells.append(
+            {
+                "content": [
+                    {
+                        "startIndex": start,
+                        "endIndex": end,
+                        "paragraph": {"elements": []},
+                    }
+                ]
+            }
+        )
+    return [
+        {
+            "startIndex": table_start,
+            "table": {
+                "tableRows": [
+                    {"tableCells": cells},
+                ]
+            },
+        }
+    ]
+
+
+@pytest.mark.unit
+class TestHeaderBoldRange:
+    """Regression: updateTextStyle for header cells must span the full cell text.
+
+    Previously endIndex was start_idx + 1, which only bolded the first character.
+    """
+
+    def test_bold_range_spans_full_header_text(self) -> None:
+        """For a 5-char header cell the bold range endIndex must be > startIndex + 1."""
+        table_start = 10
+        # Cell with text spanning indices 12..17 (5 chars: "Hello" + trailing newline)
+        body_content = _make_body_content(table_start, [(12, 17)])
+        ranges = _find_header_cell_indices(body_content, table_start)
+        assert len(ranges) == 1
+        start, end = ranges[0]
+        assert (
+            end > start + 1
+        ), f"endIndex ({end}) must be > startIndex + 1 ({start + 1}) for a multi-char header cell"
+
+    def test_bold_request_uses_full_range(self) -> None:
+        """_build_header_requests must emit endIndex equal to the cell's endIndex."""
+        table_start = 5
+        # Two header cells: "Name" (4 chars, indices 7..12), "Value" (5 chars, 14..20)
+        cell_ranges: list[tuple[int, int]] = [(7, 12), (14, 20)]
+        requests = _build_header_requests(table_start, 2, cell_ranges)
+        bold_reqs = [
+            r
+            for r in requests
+            if "updateTextStyle" in r and r["updateTextStyle"]["textStyle"].get("bold")
+        ]
+        assert len(bold_reqs) == 2
+        # First cell: endIndex must be 12 (not 7+1=8)
+        r0 = bold_reqs[0]["updateTextStyle"]["range"]
+        assert r0["startIndex"] == 7
+        assert r0["endIndex"] == 12, f"Expected endIndex=12, got {r0['endIndex']}"
+        # Second cell: endIndex must be 20 (not 14+1=15)
+        r1 = bold_reqs[1]["updateTextStyle"]["range"]
+        assert r1["startIndex"] == 14
+        assert r1["endIndex"] == 20, f"Expected endIndex=20, got {r1['endIndex']}"
+
+    def test_two_col_table_bold_ranges_both_multichar(self) -> None:
+        """All columns in a 2-col header table must have bold endIndex > startIndex + 1."""
+        table_start = 3
+        header_cells = [(5, 13), (15, 25)]  # "ColName" (8 chars), "LongHeader" (10 chars)
+        ranges = _find_header_cell_indices(
+            _make_body_content(table_start, header_cells), table_start
+        )
+        for i, (start, end) in enumerate(ranges):
+            assert end > start + 1, f"Column {i}: endIndex={end} must be > startIndex+1={start + 1}"

--- a/tests/unit/test_markdown_file_to_doc.py
+++ b/tests/unit/test_markdown_file_to_doc.py
@@ -1,0 +1,487 @@
+"""Unit tests for markdown_file_to_doc tool.
+
+Tests cover:
+- Tool definition / schema
+- Markdown parser (parse_markdown)
+- Inline run parser (_parse_inline_runs)
+- DocBuilder request generation
+- Handler: missing inputs, file-not-found, new-doc creation, in-place update
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from gworkspace_mcp.server.services.docs.markdown_file import (
+    TOOLS,
+    _DocBuilder,
+    _parse_inline_runs,
+    get_handlers,
+    parse_markdown,
+)
+
+# ---------------------------------------------------------------------------
+# Tool schema tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestMarkdownFileToDocTool:
+    def test_tool_registered(self) -> None:
+        names = [t.name for t in TOOLS]
+        assert "markdown_file_to_doc" in names
+
+    def test_tool_description_nonempty(self) -> None:
+        tool = next(t for t in TOOLS if t.name == "markdown_file_to_doc")
+        assert tool.description
+        assert len(tool.description) > 20
+
+    def test_tool_description_mentions_key_features(self) -> None:
+        tool = next(t for t in TOOLS if t.name == "markdown_file_to_doc")
+        desc = tool.description.lower()
+        assert "file" in desc
+        assert "border" in desc or "table" in desc
+
+    def test_schema_has_markdown_file_path_property(self) -> None:
+        tool = next(t for t in TOOLS if t.name == "markdown_file_to_doc")
+        props = tool.inputSchema.get("properties", {})
+        assert "markdown_file_path" in props
+
+    def test_schema_has_document_id_property(self) -> None:
+        tool = next(t for t in TOOLS if t.name == "markdown_file_to_doc")
+        props = tool.inputSchema.get("properties", {})
+        assert "document_id" in props
+
+    def test_schema_has_account_property(self) -> None:
+        tool = next(t for t in TOOLS if t.name == "markdown_file_to_doc")
+        props = tool.inputSchema.get("properties", {})
+        assert "account" in props
+
+
+# ---------------------------------------------------------------------------
+# Inline run parser tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestParseInlineRuns:
+    def test_plain_text(self) -> None:
+        runs = _parse_inline_runs("hello world")
+        assert len(runs) == 1
+        assert runs[0]["text"] == "hello world"
+        assert not runs[0]["bold"]
+        assert runs[0]["link"] is None
+
+    def test_bold(self) -> None:
+        runs = _parse_inline_runs("**bold text**")
+        assert any(r["bold"] and r["text"] == "bold text" for r in runs)
+
+    def test_italic(self) -> None:
+        runs = _parse_inline_runs("*italic text*")
+        assert any(r["italic"] and r["text"] == "italic text" for r in runs)
+
+    def test_inline_code(self) -> None:
+        runs = _parse_inline_runs("`some code`")
+        assert any(r["code"] and r["text"] == "some code" for r in runs)
+
+    def test_link(self) -> None:
+        runs = _parse_inline_runs("[click here](https://example.com)")
+        assert any(r["link"] == "https://example.com" and r["text"] == "click here" for r in runs)
+
+    def test_mixed_content(self) -> None:
+        runs = _parse_inline_runs("See [docs](https://example.com) for **details**.")
+        texts = [r["text"] for r in runs]
+        assert "docs" in texts
+        assert "details" in texts
+        link_run = next(r for r in runs if r["link"])
+        assert link_run["link"] == "https://example.com"
+
+    def test_empty_string(self) -> None:
+        runs = _parse_inline_runs("")
+        # Should return at least one run (possibly empty text)
+        assert isinstance(runs, list)
+
+
+# ---------------------------------------------------------------------------
+# Markdown parser tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestParseMarkdown:
+    def test_heading_h1(self) -> None:
+        blocks = parse_markdown("# Title\n")
+        headings = [b for b in blocks if b["type"] == "heading"]
+        assert len(headings) == 1
+        assert headings[0]["level"] == 1
+        assert headings[0]["runs"][0]["text"] == "Title"
+
+    def test_heading_h3(self) -> None:
+        blocks = parse_markdown("### Section\n")
+        h = next(b for b in blocks if b["type"] == "heading")
+        assert h["level"] == 3
+
+    def test_paragraph(self) -> None:
+        blocks = parse_markdown("Hello world\n")
+        paras = [b for b in blocks if b["type"] == "paragraph"]
+        assert len(paras) >= 1
+        text = "".join(r["text"] for r in paras[0]["runs"])
+        assert "Hello world" in text
+
+    def test_blank_line(self) -> None:
+        blocks = parse_markdown("\n")
+        assert any(b["type"] == "blank" for b in blocks)
+
+    def test_fenced_code_block(self) -> None:
+        md = "```python\nprint('hi')\n```\n"
+        blocks = parse_markdown(md)
+        code_blocks = [b for b in blocks if b["type"] == "code"]
+        assert len(code_blocks) == 1
+        assert "print" in code_blocks[0]["text"]
+
+    def test_unordered_list(self) -> None:
+        md = "- item one\n- item two\n"
+        blocks = parse_markdown(md)
+        bullets = [b for b in blocks if b["type"] == "bullet"]
+        assert len(bullets) == 2
+
+    def test_ordered_list(self) -> None:
+        md = "1. first\n2. second\n"
+        blocks = parse_markdown(md)
+        ordered = [b for b in blocks if b["type"] == "ordered"]
+        assert len(ordered) == 2
+
+    def test_table(self) -> None:
+        md = "| Col A | Col B |\n|-------|-------|\n| r1c1 | r1c2 |\n| r2c1 | r2c2 |\n"
+        blocks = parse_markdown(md)
+        tables = [b for b in blocks if b["type"] == "table"]
+        assert len(tables) == 1
+        t = tables[0]
+        assert t["headers"] == ["Col A", "Col B"]
+        assert len(t["rows"]) == 2
+        assert t["rows"][0] == ["r1c1", "r1c2"]
+
+    def test_horizontal_rule(self) -> None:
+        blocks = parse_markdown("---\n")
+        rules = [b for b in blocks if b["type"] == "rule"]
+        assert len(rules) == 1
+
+    def test_mixed_document(self) -> None:
+        md = (
+            "# Heading 1\n\n"
+            "A paragraph.\n\n"
+            "## Heading 2\n\n"
+            "| A | B |\n|---|---|\n| 1 | 2 |\n\n"
+            "- bullet\n"
+        )
+        blocks = parse_markdown(md)
+        types = {b["type"] for b in blocks}
+        assert "heading" in types
+        assert "paragraph" in types
+        assert "table" in types
+        assert "bullet" in types
+
+
+# ---------------------------------------------------------------------------
+# DocBuilder tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestDocBuilder:
+    def test_heading_emits_insert_and_style(self) -> None:
+        builder = _DocBuilder(start_index=1)
+        builder.add_heading(
+            1, [{"text": "My Title", "bold": False, "italic": False, "code": False, "link": None}]
+        )
+        requests, _ = builder.build()
+        insert_reqs = [r for r in requests if "insertText" in r]
+        style_reqs = [r for r in requests if "updateParagraphStyle" in r]
+        assert insert_reqs
+        assert any("My Title" in r["insertText"]["text"] for r in insert_reqs)
+        assert style_reqs
+        assert (
+            style_reqs[0]["updateParagraphStyle"]["paragraphStyle"]["namedStyleType"] == "HEADING_1"
+        )
+
+    def test_paragraph_emits_insert(self) -> None:
+        builder = _DocBuilder(start_index=1)
+        builder.add_paragraph(
+            [{"text": "Hello", "bold": False, "italic": False, "code": False, "link": None}]
+        )
+        requests, _ = builder.build()
+        assert any("insertText" in r and "Hello" in r["insertText"]["text"] for r in requests)
+
+    def test_bold_run_emits_text_style(self) -> None:
+        builder = _DocBuilder(start_index=1)
+        builder.add_paragraph(
+            [{"text": "bold", "bold": True, "italic": False, "code": False, "link": None}]
+        )
+        requests, _ = builder.build()
+        style_reqs = [r for r in requests if "updateTextStyle" in r]
+        assert any(r["updateTextStyle"]["textStyle"].get("bold") for r in style_reqs)
+
+    def test_link_run_emits_link_style(self) -> None:
+        builder = _DocBuilder(start_index=1)
+        builder.add_paragraph(
+            [
+                {
+                    "text": "click",
+                    "bold": False,
+                    "italic": False,
+                    "code": False,
+                    "link": "https://example.com",
+                }
+            ]
+        )
+        requests, _ = builder.build()
+        style_reqs = [r for r in requests if "updateTextStyle" in r]
+        assert any(
+            r["updateTextStyle"]["textStyle"].get("link", {}).get("url") == "https://example.com"
+            for r in style_reqs
+        )
+
+    def test_table_emits_insert_table_and_deferred(self) -> None:
+        builder = _DocBuilder(start_index=1)
+        builder.add_table(["Col A", "Col B"], [["r1c1", "r1c2"], ["r2c1", "r2c2"]])
+        requests, deferred = builder.build()
+        assert any("insertTable" in r for r in requests)
+        assert any(d.get("_fill_table") for d in deferred)
+
+    def test_table_deferred_has_correct_metadata(self) -> None:
+        builder = _DocBuilder(start_index=1)
+        builder.add_table(["H1", "H2"], [["a", "b"]])
+        _, deferred = builder.build()
+        sentinel = next(d for d in deferred if d.get("_fill_table"))
+        assert sentinel["num_rows"] == 2  # 1 header + 1 data row
+        assert sentinel["num_cols"] == 2
+        assert sentinel["all_rows"] == [["H1", "H2"], ["a", "b"]]
+
+    def test_index_advances_correctly_for_text(self) -> None:
+        builder = _DocBuilder(start_index=1)
+        builder.add_paragraph(
+            [{"text": "abc", "bold": False, "italic": False, "code": False, "link": None}]
+        )
+        # "abc" + "\n" = 4 chars, so index should be 5
+        assert builder.index == 5
+
+    def test_heading_h6(self) -> None:
+        builder = _DocBuilder(start_index=1)
+        builder.add_heading(
+            6, [{"text": "deep", "bold": False, "italic": False, "code": False, "link": None}]
+        )
+        requests, _ = builder.build()
+        style = next(r for r in requests if "updateParagraphStyle" in r)
+        assert style["updateParagraphStyle"]["paragraphStyle"]["namedStyleType"] == "HEADING_6"
+
+    def test_bullet_emits_create_paragraph_bullets(self) -> None:
+        builder = _DocBuilder(start_index=1)
+        builder.add_bullet(
+            0, [{"text": "item", "bold": False, "italic": False, "code": False, "link": None}]
+        )
+        requests, _ = builder.build()
+        assert any("createParagraphBullets" in r for r in requests)
+
+    def test_ordered_emits_create_paragraph_bullets(self) -> None:
+        builder = _DocBuilder(start_index=1)
+        builder.add_ordered(
+            [{"text": "first", "bold": False, "italic": False, "code": False, "link": None}]
+        )
+        requests, _ = builder.build()
+        assert any("createParagraphBullets" in r for r in requests)
+
+    def test_code_block_emits_monospace_style(self) -> None:
+        builder = _DocBuilder(start_index=1)
+        builder.add_code_block("def foo(): pass")
+        requests, _ = builder.build()
+        style_reqs = [r for r in requests if "updateTextStyle" in r]
+        assert any(
+            "Courier New" in str(r["updateTextStyle"]["textStyle"].get("weightedFontFamily", {}))
+            for r in style_reqs
+        )
+
+
+# ---------------------------------------------------------------------------
+# Handler tests
+# ---------------------------------------------------------------------------
+
+
+def _make_service() -> MagicMock:
+    """Build a minimal mock BaseService."""
+    svc = MagicMock()
+    svc._make_request = AsyncMock()
+    svc._make_raw_request = AsyncMock()
+    return svc
+
+
+@pytest.mark.unit
+class TestMarkdownFileTodocHandler:
+    @pytest.mark.asyncio
+    async def test_raises_when_no_input(self) -> None:
+        svc = _make_service()
+        handlers = get_handlers(svc)
+        with pytest.raises((ValueError, FileNotFoundError)):
+            await handlers["markdown_file_to_doc"]({})
+
+    @pytest.mark.asyncio
+    async def test_raises_file_not_found(self) -> None:
+        svc = _make_service()
+        handlers = get_handlers(svc)
+        with pytest.raises(FileNotFoundError):
+            await handlers["markdown_file_to_doc"](
+                {"markdown_file_path": "/nonexistent/path/file.md", "title": "Test"}
+            )
+
+    @pytest.mark.asyncio
+    async def test_create_new_doc_with_inline_content(self) -> None:
+        svc = _make_service()
+        # _make_request: first call creates doc, remaining are batchUpdates, last is file meta
+        svc._make_request.side_effect = [
+            # create document
+            {"documentId": "new_doc_123", "title": "Test Doc"},
+            # batchUpdate (insert requests) - may be called multiple times
+            {"writeControl": {}},
+            # file meta
+            {
+                "id": "new_doc_123",
+                "name": "Test Doc",
+                "webViewLink": "https://docs.google.com/abc",
+                "mimeType": "application/vnd.google-apps.document",
+            },
+        ]
+        handlers = get_handlers(svc)
+        result = await handlers["markdown_file_to_doc"](
+            {"markdown_content": "# Hello\n\nWorld.\n", "title": "Test Doc"}
+        )
+        assert result["document_id"] == "new_doc_123"
+        assert "webViewLink" in result
+        assert result["status"] == "published"
+
+    @pytest.mark.asyncio
+    async def test_in_place_update_calls_delete_then_insert(self) -> None:
+        svc = _make_service()
+        # _make_request calls: GET body, DELETE batchUpdate, INSERT batchUpdates..., GET file meta
+        svc._make_request.side_effect = [
+            # GET document body to clear
+            {
+                "body": {
+                    "content": [
+                        {"startIndex": 0, "endIndex": 1},
+                        {"startIndex": 1, "endIndex": 50},
+                    ]
+                }
+            },
+            # DELETE batchUpdate (clear body)
+            {"writeControl": {}},
+            # INSERT batchUpdate
+            {"writeControl": {}},
+            # GET file meta
+            {
+                "id": "existing_doc_456",
+                "name": "My Doc",
+                "webViewLink": "https://docs.google.com/existing",
+                "mimeType": "application/vnd.google-apps.document",
+            },
+        ]
+        handlers = get_handlers(svc)
+        result = await handlers["markdown_file_to_doc"](
+            {
+                "markdown_content": "# Update\n\nNew content.\n",
+                "document_id": "existing_doc_456",
+                "title": "My Doc",
+            }
+        )
+        assert result["document_id"] == "existing_doc_456"
+        assert result["status"] == "updated"
+        # Verify first call was a GET (body fetch for clearing)
+        first_call = svc._make_request.call_args_list[0]
+        assert first_call.args[0] == "GET"
+
+    @pytest.mark.asyncio
+    async def test_reads_file_from_path(self, tmp_path: Path) -> None:
+        md_file = tmp_path / "test.md"
+        md_file.write_text("# File Heading\n\nContent from file.\n", encoding="utf-8")
+
+        svc = _make_service()
+        svc._make_request.side_effect = [
+            {"documentId": "file_doc_789", "title": "File Test"},
+            {"writeControl": {}},
+            {
+                "id": "file_doc_789",
+                "name": "File Test",
+                "webViewLink": "https://docs.google.com/file",
+                "mimeType": "application/vnd.google-apps.document",
+            },
+        ]
+        handlers = get_handlers(svc)
+        result = await handlers["markdown_file_to_doc"](
+            {"markdown_file_path": str(md_file), "title": "File Test"}
+        )
+        assert result["document_id"] == "file_doc_789"
+        assert result["blocks_processed"] > 0
+
+    @pytest.mark.asyncio
+    async def test_file_path_takes_precedence_over_inline_content(self, tmp_path: Path) -> None:
+        md_file = tmp_path / "priority.md"
+        md_file.write_text("# From File\n", encoding="utf-8")
+
+        svc = _make_service()
+        svc._make_request.side_effect = [
+            {"documentId": "prio_doc", "title": "Priority Test"},
+            {"writeControl": {}},
+            {
+                "id": "prio_doc",
+                "name": "Priority Test",
+                "webViewLink": "https://docs.google.com/prio",
+                "mimeType": "application/vnd.google-apps.document",
+            },
+        ]
+        handlers = get_handlers(svc)
+        # Both provided — file path wins
+        result = await handlers["markdown_file_to_doc"](
+            {
+                "markdown_file_path": str(md_file),
+                "markdown_content": "# From Inline\n",
+                "title": "Priority Test",
+            }
+        )
+        # Should have processed the file content (1 heading)
+        assert result["blocks_processed"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_handler_registered_in_handlers_dict(self) -> None:
+        svc = _make_service()
+        handlers = get_handlers(svc)
+        assert "markdown_file_to_doc" in handlers
+        assert callable(handlers["markdown_file_to_doc"])
+
+    @pytest.mark.asyncio
+    async def test_large_doc_uses_chunked_batch_updates(self, tmp_path: Path) -> None:
+        """Verify a 500-paragraph document issues multiple batchUpdate calls."""
+        lines = ["# Big Doc\n\n"]
+        for i in range(250):
+            lines.append(f"Paragraph {i} with some content that makes it non-trivial.\n\n")
+        md_file = tmp_path / "large.md"
+        md_file.write_text("".join(lines), encoding="utf-8")
+
+        svc = _make_service()
+        # Accept any number of calls
+        svc._make_request.return_value = {
+            "documentId": "large_doc",
+            "title": "Big Doc",
+            "writeControl": {},
+            "id": "large_doc",
+            "name": "Big Doc",
+            "webViewLink": "https://docs.google.com/large",
+            "mimeType": "application/vnd.google-apps.document",
+        }
+        handlers = get_handlers(svc)
+        result = await handlers["markdown_file_to_doc"](
+            {"markdown_file_path": str(md_file), "title": "Big Doc"}
+        )
+        assert result["document_id"] == "large_doc"
+        # Should have called _make_request multiple times (create + multiple chunks)
+        assert svc._make_request.call_count >= 2

--- a/tests/unit/test_markdown_file_to_doc.py
+++ b/tests/unit/test_markdown_file_to_doc.py
@@ -18,6 +18,7 @@ import pytest
 from gworkspace_mcp.server.services.docs.markdown_file import (
     TOOLS,
     _DocBuilder,
+    _is_path_under,
     _parse_inline_runs,
     get_handlers,
     parse_markdown,
@@ -327,31 +328,33 @@ class TestMarkdownFileTodocHandler:
             await handlers["markdown_file_to_doc"]({})
 
     @pytest.mark.asyncio
-    async def test_raises_file_not_found(self) -> None:
+    async def test_raises_file_not_found(self, tmp_path: Path) -> None:
         svc = _make_service()
         handlers = get_handlers(svc)
+        # Use a path under the allowed temp directory that simply doesn't exist.
+        nonexistent = tmp_path / "does_not_exist.md"
         with pytest.raises(FileNotFoundError):
             await handlers["markdown_file_to_doc"](
-                {"markdown_file_path": "/nonexistent/path/file.md", "title": "Test"}
+                {"markdown_file_path": str(nonexistent), "title": "Test"}
             )
 
     @pytest.mark.asyncio
     async def test_create_new_doc_with_inline_content(self) -> None:
         svc = _make_service()
-        # _make_request: first call creates doc, remaining are batchUpdates, last is file meta
-        svc._make_request.side_effect = [
-            # create document
-            {"documentId": "new_doc_123", "title": "Test Doc"},
-            # batchUpdate (insert requests) - may be called multiple times
-            {"writeControl": {}},
-            # file meta
-            {
-                "id": "new_doc_123",
-                "name": "Test Doc",
-                "webViewLink": "https://docs.google.com/abc",
-                "mimeType": "application/vnd.google-apps.document",
-            },
-        ]
+        # Use return_value so any number of batchUpdate/GET calls all succeed.
+        # The handler issues: POST (create doc), POST (batchUpdate inserts),
+        # optional additional POSTs for table fills, GET (file meta).
+        # A unified response dict satisfies all call shapes — only "documentId"
+        # and "id"/"webViewLink" are required by the handler.
+        svc._make_request.return_value = {
+            "documentId": "new_doc_123",
+            "title": "Test Doc",
+            "writeControl": {},
+            "id": "new_doc_123",
+            "name": "Test Doc",
+            "webViewLink": "https://docs.google.com/abc",
+            "mimeType": "application/vnd.google-apps.document",
+        }
         handlers = get_handlers(svc)
         result = await handlers["markdown_file_to_doc"](
             {"markdown_content": "# Hello\n\nWorld.\n", "title": "Test Doc"}
@@ -791,3 +794,112 @@ class TestDefaultFontBehavior:
             == "Courier New"
             for r in text_style_reqs
         ), "Inline code must use Courier New"
+
+
+# ---------------------------------------------------------------------------
+# Path-traversal guard tests (finding 2)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestPathTraversalGuard:
+    """The handler must reject paths outside the CWD or home directory."""
+
+    def test_is_path_under_true_for_home_child(self) -> None:
+        home = Path.home()
+        child = home / "some" / "file.md"
+        assert _is_path_under(child, home) is True
+
+    def test_is_path_under_false_for_etc_passwd(self) -> None:
+        home = Path.home()
+        assert _is_path_under(Path("/etc/passwd"), home) is False
+
+    def test_is_path_under_false_for_root(self) -> None:
+        home = Path.home()
+        cwd = Path.cwd()
+        assert _is_path_under(Path("/"), home) is False
+        assert _is_path_under(Path("/"), cwd) is False
+
+    def test_is_path_under_true_for_same_path(self) -> None:
+        home = Path.home()
+        assert _is_path_under(home, home) is True
+
+    @pytest.mark.asyncio
+    async def test_handler_rejects_path_outside_allowed_roots(self) -> None:
+        """Handler raises ValueError for a path outside CWD and home."""
+        svc = _make_service()
+        handlers = get_handlers(svc)
+        # /etc/passwd is never under CWD or home on any supported platform.
+        with pytest.raises(ValueError, match="outside allowed directories"):
+            await handlers["markdown_file_to_doc"](
+                {"markdown_file_path": "/etc/passwd", "title": "Hack Attempt"}
+            )
+
+    @pytest.mark.asyncio
+    async def test_handler_allows_in_tree_path(self, tmp_path: Path) -> None:
+        """Handler reads a file under the system temp dir (an allowed root)."""
+        test_file = tmp_path / "allowed_test.md"
+        test_file.write_text("# Allowed\n", encoding="utf-8")
+        svc = _make_service()
+        svc._make_request.return_value = {
+            "documentId": "allowed_doc",
+            "title": "Allowed",
+            "writeControl": {},
+            "id": "allowed_doc",
+            "name": "Allowed",
+            "webViewLink": "https://docs.google.com/allowed",
+            "mimeType": "application/vnd.google-apps.document",
+        }
+        handlers = get_handlers(svc)
+        result = await handlers["markdown_file_to_doc"](
+            {"markdown_file_path": str(test_file), "title": "Allowed"}
+        )
+        assert result["document_id"] == "allowed_doc"
+
+
+# ---------------------------------------------------------------------------
+# GFM table continuation guard tests (finding 3)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTableContinuationGuard:
+    """The table parser must not absorb prose lines that merely contain '|'."""
+
+    def test_table_does_not_absorb_following_prose_with_pipe(self) -> None:
+        """A table immediately followed by prose containing '|' must not include
+        the prose line inside the table block."""
+        md = (
+            "| Col A | Col B |\n|-------|-------|\n| r1c1  | r1c2  |\n\nUse | to separate values.\n"
+        )
+        blocks = parse_markdown(md)
+        tables = [b for b in blocks if b["type"] == "table"]
+        assert len(tables) == 1, f"Expected 1 table, got {len(tables)}"
+        t = tables[0]
+        # The prose line must NOT appear as a row
+        assert (
+            len(t["rows"]) == 1
+        ), f"Table should have 1 data row, got {len(t['rows'])}: {t['rows']}"
+        # The prose must appear as a paragraph block
+        paras = [b for b in blocks if b["type"] == "paragraph"]
+        para_text = " ".join("".join(r["text"] for r in p["runs"]) for p in paras)
+        assert "Use" in para_text and "separate" in para_text
+
+    def test_table_does_not_absorb_prose_without_blank_line(self) -> None:
+        """Even without a blank separator, a non-pipe-leading line ends the table."""
+        md = "| A | B |\n|---|---|\n| 1 | 2 |\nThis is prose with a | pipe in it.\n"
+        blocks = parse_markdown(md)
+        tables = [b for b in blocks if b["type"] == "table"]
+        assert len(tables) == 1
+        t = tables[0]
+        assert (
+            len(t["rows"]) == 1
+        ), f"Table should have 1 data row but got {len(t['rows'])}: {t['rows']}"
+
+    def test_table_ends_at_blank_line(self) -> None:
+        """A blank line always ends the table regardless of what follows."""
+        md = "| X |\n|---|\n| v |\n\nNext paragraph.\n"
+        blocks = parse_markdown(md)
+        tables = [b for b in blocks if b["type"] == "table"]
+        assert len(tables) == 1
+        assert len(tables[0]["rows"]) == 1

--- a/tests/unit/test_markdown_file_to_doc.py
+++ b/tests/unit/test_markdown_file_to_doc.py
@@ -485,3 +485,309 @@ class TestMarkdownFileTodocHandler:
         assert result["document_id"] == "large_doc"
         # Should have called _make_request multiple times (create + multiple chunks)
         assert svc._make_request.call_count >= 2
+
+
+# ---------------------------------------------------------------------------
+# Bug-fix regression tests (confirmed bugs from real output review)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.unit
+class TestTableCellOrder:
+    """Bug 1: Table cells were scrambled due to forward-order insertion.
+
+    The Docs API insertText at index N shifts all subsequent indices forward.
+    Cells must be inserted in reverse document order so earlier insertions
+    do not invalidate later indices.
+    """
+
+    def test_5col_3row_table_deferred_cell_order(self) -> None:
+        """5-column, 3-row table: all_rows contains cells in correct (row,col) order."""
+        headers = ["Work Type", "Count", "%", "LOC", "LOC%"]
+        rows = [
+            ["Bug fixes", "1,277", "35.8%", "366,892", "25.6%"],
+            ["Features", "800", "22.4%", "500,000", "34.9%"],
+        ]
+        builder = _DocBuilder(start_index=1)
+        builder.add_table(headers, rows)
+        _, deferred = builder.build()
+        sentinel = next(d for d in deferred if d.get("_fill_table"))
+
+        all_rows = sentinel["all_rows"]
+        assert len(all_rows) == 3  # header + 2 data rows
+        assert all_rows[0] == headers
+        assert all_rows[1] == rows[0]
+        assert all_rows[2] == rows[1]
+
+        # Verify cell values are not concatenated/transposed
+        assert all_rows[1][0] == "Bug fixes"
+        assert all_rows[1][1] == "1,277"
+        assert all_rows[1][2] == "35.8%"
+        assert all_rows[1][3] == "366,892"
+        assert all_rows[1][4] == "25.6%"
+        assert all_rows[2][0] == "Features"
+
+    def test_table_cell_insertions_are_sorted_descending(self) -> None:
+        """Simulate the Phase 1 fill logic: verify insertions would be sorted in
+        descending index order (reverse document order), ensuring no index drift."""
+        # Simulate table cell content as returned by the Docs API after insertTable.
+        # Each cell has a "content" list with a paragraph at a known startIndex.
+        # We construct a fake table structure matching the Docs API shape.
+        all_rows = [
+            ["H1", "H2", "H3", "H4", "H5"],  # header
+            ["r1c1", "r1c2", "r1c3", "r1c4", "r1c5"],  # row 1
+            ["r2c1", "r2c2", "r2c3", "r2c4", "r2c5"],  # row 2
+        ]
+
+        def _make_cell(start_idx: int, text: str) -> dict:
+            return {"content": [{"startIndex": start_idx, "paragraph": {}}]}
+
+        # Assign realistic ascending startIndex values
+        # (actual values from a 5-col empty table post-insertTable)
+        start_indices = [
+            # row 0
+            [2, 4, 6, 8, 10],
+            # row 1
+            [13, 15, 17, 19, 21],
+            # row 2
+            [24, 26, 28, 30, 32],
+        ]
+
+        # Replicate the fill logic from _fill_tables_and_style to verify ordering
+        cell_insertions: list[tuple[int, str]] = []
+        for row_i, row_data in enumerate(all_rows):
+            for col_i, cell_text in enumerate(row_data):
+                para_start = start_indices[row_i][col_i]
+                if cell_text.strip():
+                    cell_insertions.append((para_start, cell_text))
+
+        cell_insertions.sort(key=lambda x: x[0], reverse=True)
+
+        # Assert descending order (last cell inserted first)
+        indices = [idx for idx, _ in cell_insertions]
+        assert indices == sorted(
+            indices, reverse=True
+        ), "Cell insertions must be in descending index order"
+
+        # Assert the first insertion (highest index) is the last cell
+        assert cell_insertions[0][0] == 32
+        assert cell_insertions[0][1] == "r2c5"
+
+        # Assert the last insertion (lowest index) is the first cell
+        assert cell_insertions[-1][0] == 2
+        assert cell_insertions[-1][1] == "H1"
+
+        # Assert no cell text was concatenated
+        texts = [t for _, t in cell_insertions]
+        assert "H1H2" not in "".join(texts)
+        assert all(t in [c for row in all_rows for c in row] for t in texts)
+
+
+@pytest.mark.unit
+class TestHardLineBreaks:
+    """Bug 2: Markdown hard line breaks (two trailing spaces) were collapsed.
+
+    Lines ending in two spaces must produce separate line-break runs (\\n)
+    within the same paragraph block, NOT joined with a space.
+    """
+
+    def test_three_line_hard_break_title_block(self) -> None:
+        """The canonical title block: 3 lines with trailing double-space hard breaks."""
+        md = (
+            "**Status:** DRAFT  \n"
+            "**Prepared for:** Robert Matsuoka, Chief Technology Officer  \n"
+            "**Date:** 2026-06-04"
+        )
+        blocks = parse_markdown(md)
+        # All three lines are in one paragraph block
+        para_blocks = [b for b in blocks if b["type"] == "paragraph"]
+        assert len(para_blocks) == 1
+
+        runs = para_blocks[0]["runs"]
+        run_texts = [r["text"] for r in runs]
+
+        # Must contain hard line-break characters (\n) between the logical lines
+        newline_runs = [r for r in runs if r["text"] == "\n"]
+        assert (
+            len(newline_runs) == 2
+        ), f"Expected 2 hard line-break \\n runs, got {len(newline_runs)}. Runs: {run_texts}"
+
+        # The logical content of each line must be present
+        all_text = "".join(run_texts)
+        assert "Status:" in all_text
+        assert "DRAFT" in all_text
+        assert "Prepared for:" in all_text
+        assert "Robert Matsuoka" in all_text
+        assert "Date:" in all_text
+        assert "2026-06-04" in all_text
+
+    def test_hard_break_inserts_newline_in_doc_requests(self) -> None:
+        """DocBuilder must emit a literal \\n insertText for hard breaks."""
+        md = "line one  \nline two  \nline three"
+        blocks = parse_markdown(md)
+        builder = _DocBuilder(start_index=1)
+        for b in blocks:
+            if b["type"] == "paragraph":
+                builder.add_paragraph(b["runs"])
+        requests, _ = builder.build()
+
+        insert_texts = [r["insertText"]["text"] for r in requests if "insertText" in r]
+        # Count standalone newline insertions (hard breaks, not the paragraph-ending \n)
+        # The paragraph-ending \n is the last insert; hard breaks are \n runs within
+        newline_inserts = [t for t in insert_texts if t == "\n"]
+        assert len(newline_inserts) >= 2, (
+            f"Expected at least 2 \\n insertText requests for 2 hard breaks, "
+            f"got {len(newline_inserts)}. All texts: {insert_texts}"
+        )
+
+    def test_soft_continuation_joins_with_space(self) -> None:
+        """Lines WITHOUT trailing double-space are joined with a space (soft wrap)."""
+        md = "first line\nsecond line\nthird line"
+        blocks = parse_markdown(md)
+        para_blocks = [b for b in blocks if b["type"] == "paragraph"]
+        assert len(para_blocks) == 1
+
+        runs = para_blocks[0]["runs"]
+        # No hard break \n runs
+        newline_runs = [r for r in runs if r["text"] == "\n"]
+        assert len(newline_runs) == 0
+
+        all_text = "".join(r["text"] for r in runs)
+        # Lines joined with spaces
+        assert "first line" in all_text
+        assert "second line" in all_text
+        assert "third line" in all_text
+
+
+@pytest.mark.unit
+class TestEmphasisParsing:
+    """Bug 3: **bold** and *italic* emphasis must be parsed correctly.
+
+    Stray/standalone * (e.g. footnote marker like ~49.7%*) and ~ must be
+    treated as literal text, not emphasis.
+    """
+
+    def test_bold_double_asterisk(self) -> None:
+        runs = _parse_inline_runs("**bold text**")
+        bold_runs = [r for r in runs if r["bold"]]
+        assert len(bold_runs) == 1
+        assert bold_runs[0]["text"] == "bold text"
+        assert not bold_runs[0]["italic"]
+
+    def test_italic_single_asterisk(self) -> None:
+        runs = _parse_inline_runs("*italic text*")
+        italic_runs = [r for r in runs if r["italic"]]
+        assert len(italic_runs) == 1
+        assert italic_runs[0]["text"] == "italic text"
+        assert not italic_runs[0]["bold"]
+
+    def test_stray_asterisk_footnote_not_italic(self) -> None:
+        """~49.7%* should be plain text, not italicized."""
+        runs = _parse_inline_runs("~49.7%*")
+        assert len(runs) == 1
+        assert runs[0]["text"] == "~49.7%*"
+        assert not runs[0]["italic"]
+        assert not runs[0]["bold"]
+
+    def test_stray_trailing_asterisk_not_italic(self) -> None:
+        """'score of 95%*' should be plain text."""
+        runs = _parse_inline_runs("score of 95%*")
+        assert all(not r["italic"] for r in runs)
+        all_text = "".join(r["text"] for r in runs)
+        assert "95%*" in all_text
+
+    def test_tilde_prefix_is_literal(self) -> None:
+        """~ is not a formatting marker; ~text should be literal."""
+        runs = _parse_inline_runs("~49.7%* of budget")
+        assert all(not r["italic"] and not r["bold"] for r in runs)
+
+    def test_bold_followed_by_literal(self) -> None:
+        """**Status:** DRAFT — bold Status: then literal ' DRAFT'."""
+        runs = _parse_inline_runs("**Status:** DRAFT")
+        bold_runs = [r for r in runs if r["bold"]]
+        assert any(r["text"] == "Status:" for r in bold_runs)
+        plain_runs = [r for r in runs if not r["bold"] and not r["italic"]]
+        plain_text = "".join(r["text"] for r in plain_runs)
+        assert "DRAFT" in plain_text
+
+    def test_no_italic_when_asterisk_surrounded_by_spaces(self) -> None:
+        """'a * b * c' should not become italic since the content starts/ends with spaces."""
+        runs = _parse_inline_runs("a * b * c")
+        assert all(not r["italic"] for r in runs)
+
+    def test_mixed_bold_italic_link(self) -> None:
+        """A mix of bold, italic and link in one line."""
+        text = "**bold** and *italic* and [link](http://x.com)"
+        runs = _parse_inline_runs(text)
+        assert any(r["bold"] and r["text"] == "bold" for r in runs)
+        assert any(r["italic"] and r["text"] == "italic" for r in runs)
+        assert any(r["link"] == "http://x.com" for r in runs)
+
+
+@pytest.mark.unit
+class TestDefaultFontBehavior:
+    """Bug 4: The tool must NOT set an explicit font_family on normal body text.
+
+    Headings should use named styles (which carry the theme font).
+    Inline code uses Courier New — that is intentional and correct.
+    """
+
+    def test_normal_paragraph_has_no_font_family_override(self) -> None:
+        """A plain paragraph must not emit a weightedFontFamily updateTextStyle."""
+        builder = _DocBuilder(start_index=1)
+        builder.add_paragraph(
+            [
+                {
+                    "text": "Normal body text.",
+                    "bold": False,
+                    "italic": False,
+                    "code": False,
+                    "link": None,
+                }
+            ]
+        )
+        requests, _ = builder.build()
+        text_style_reqs = [r for r in requests if "updateTextStyle" in r]
+        for req in text_style_reqs:
+            ts = req["updateTextStyle"]["textStyle"]
+            assert (
+                "weightedFontFamily" not in ts
+            ), f"Plain paragraph must not set weightedFontFamily; got: {ts}"
+
+    def test_heading_has_no_explicit_font_family(self) -> None:
+        """Headings use named styles (namedStyleType) — not explicit font overrides."""
+        builder = _DocBuilder(start_index=1)
+        builder.add_heading(
+            1,
+            [{"text": "My Heading", "bold": False, "italic": False, "code": False, "link": None}],
+        )
+        requests, _ = builder.build()
+        # updateParagraphStyle should use namedStyleType, not fontSize/fontFamily
+        para_style_reqs = [r for r in requests if "updateParagraphStyle" in r]
+        assert para_style_reqs, "Heading must emit updateParagraphStyle"
+        for req in para_style_reqs:
+            ps = req["updateParagraphStyle"]["paragraphStyle"]
+            assert "namedStyleType" in ps, "Heading must use namedStyleType"
+        # No updateTextStyle with weightedFontFamily on non-code heading text
+        text_style_reqs = [r for r in requests if "updateTextStyle" in r]
+        for req in text_style_reqs:
+            ts = req["updateTextStyle"]["textStyle"]
+            if "weightedFontFamily" in ts:
+                ff = ts["weightedFontFamily"].get("fontFamily", "")
+                assert (
+                    ff == "Courier New"
+                ), f"Only Courier New may be set via weightedFontFamily; got '{ff}'"
+
+    def test_inline_code_uses_courier_new(self) -> None:
+        """Inline code is the ONLY case where Courier New should be applied."""
+        builder = _DocBuilder(start_index=1)
+        builder.add_paragraph(
+            [{"text": "some code", "bold": False, "italic": False, "code": True, "link": None}]
+        )
+        requests, _ = builder.build()
+        text_style_reqs = [r for r in requests if "updateTextStyle" in r]
+        assert any(
+            r["updateTextStyle"]["textStyle"].get("weightedFontFamily", {}).get("fontFamily")
+            == "Courier New"
+            for r in text_style_reqs
+        ), "Inline code must use Courier New"

--- a/uv.lock
+++ b/uv.lock
@@ -510,7 +510,7 @@ wheels = [
 
 [[package]]
 name = "gworkspace-mcp"
-version = "0.5.4"
+version = "0.5.5"
 source = { editable = "." }
 dependencies = [
     { name = "click" },


### PR DESCRIPTION
## Summary

- **New tool `markdown_file_to_doc`** that fixes three failure modes in the existing `publish_markdown_to_doc`:
  1. **Truncation on large docs** — reads the file server-side via `markdown_file_path` so 700+ line / 70 KB+ documents are never cut off by context or output-token limits; inline `markdown_content` is still accepted as a fallback for small docs.
  2. **Borderless tables** — uses `updateTableCellStyle` directly via the Docs API after table insertion, guaranteeing visible borders even after Drive import (which drops DOCX table borders).
  3. **No in-place update** — supplying `document_id` clears the existing document body and re-inserts, preserving the shareable link and document ID rather than creating a new file each time.

## Parameters

| Parameter | Required | Description |
|---|---|---|
| `markdown_file_path` | if no inline content | Absolute path on server; file is read server-side |
| `markdown_content` | if no file path | Inline Markdown for small documents |
| `title` | for new docs | Document title |
| `document_id` | optional | Existing doc ID for in-place update |
| `folder_id` | optional | Drive folder for new documents |
| `account` | optional | Named Google account profile |

## What was tested

- 42 unit tests (all mock-based, zero network calls): schema, Markdown parser, inline-run parser, DocBuilder request generation, handler paths (new doc, in-place update, file read, missing inputs).
- Lint (`ruff`): pass. Type check (`mypy --ignore-missing-imports`): pass (48 source files, no issues). All pre-commit hooks pass.
- **Live end-to-end acceptance against the real Google Docs API is a follow-up verification step** — not run in this PR to avoid network calls during CI.

## Simplifications noted (follow-up items)

- Table cell filling uses a deferred re-fetch strategy (insertTable + GET after insert) rather than inline index arithmetic. This is correct and reliable but adds one extra API round-trip per table. A future optimisation could pre-calculate cell offsets to eliminate the re-fetch.
- Nested bullets use `createParagraphBullets` with `nestingLevel` as a depth hint. The Docs API does not guarantee exact visual indentation matching the source Markdown depth — this is a known API limitation that can be addressed in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)