### PR TITLE
chore: gitignore trusty-mpm session orchestration state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -96,5 +96,9 @@ kuzu-memories/
 .kuzu_memory.db
 .trusty-search/
 
+# trusty-mpm session orchestration state (local)
+.trusty-mpm/
+.trusty-mpm-worktree
+
 # FastEmbed local model/vector cache
 .fastembed_cache/


### PR DESCRIPTION
## Summary

Add trusty-mpm session orchestration artifacts to .gitignore:
- `.trusty-mpm/` — local session state and context snapshots
- `.trusty-mpm-worktree` — worktree management marker

These are temporary session-coordination files used by the trusty-mpm PM orchestrator and should not be tracked in the repository.

🤖 Generated with [Claude Code](https://claude.com/claude-code)